### PR TITLE
[FE]Fix#191 같이보기 상태에서 핀 추가시 발생하는 오류 수정

### DIFF
--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -4,10 +4,11 @@ import Clipping from '../../assets/clipping.svg';
 import Share from '../../assets/share.svg';
 import Button from '../common/Button';
 import Space from '../common/Space';
-import { useParams } from 'react-router-dom';
 import useNavigator from '../../hooks/useNavigator';
 
 export interface TopicInfoProps {
+  fullUrl?: string;
+  topicId?: string;
   topicParticipant: number;
   pinNumber: number;
   topicTitle: string;
@@ -16,17 +17,18 @@ export interface TopicInfoProps {
 }
 
 const TopicInfo = ({
+  fullUrl,
+  topicId,
   topicParticipant,
   pinNumber,
   topicTitle,
   topicOwner,
   topicDescription,
 }: TopicInfoProps) => {
-  const { topicId } = useParams();
   const { routePage } = useNavigator();
 
   const goToNewPin = () => {
-    routePage(`/new-pin?topic-id=${topicId}`);
+    routePage(`/new-pin?topic-id=${topicId}`, fullUrl);
   };
 
   const copyContent = async () => {

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -14,8 +14,10 @@ import { NewPinValuesType } from '../types/FormValues';
 import useFormValues from '../hooks/useFormValues';
 import { MarkerContext } from '../context/MarkerContext';
 import { CoordinatesContext } from '../context/CoordinatesContext';
+import { useLocation } from 'react-router-dom';
 
 const NewPin = () => {
+  const { state: prevUrl } = useLocation();
   const [topic, setTopic] = useState<TopicType | null>(null);
   const { markers, clickedMarker } = useContext(MarkerContext);
   const { clickedCoordinate, setClickedCoordinate } =
@@ -55,7 +57,10 @@ const NewPin = () => {
     e.preventDefault();
 
     await postToServer();
-    routePage(`/topics/${topic?.id}`, [topic!.id]);
+
+    if (prevUrl.length > 1) routePage(`/topics/${prevUrl}`, [topic!.id]);
+    else routePage(`/topics/${topic?.id}`, [topic!.id]);
+
     // 선택된 마커가 있으면 마커를 지도에서 제거
     if (clickedMarker) {
       clickedMarker.setMap(null);

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -28,6 +28,7 @@ const SelectedTopic = () => {
     const data = await getApi(
       `/topics/ids?ids=${topicId?.split(',').join('&ids=')}`,
     );
+    const topicHashmap = new Map([]);
 
     // 각 topic의 pin들의 좌표를 가져옴
     const newCoordinates: any = [];
@@ -45,7 +46,17 @@ const SelectedTopic = () => {
 
     setCoordinates(newCoordinates);
 
-    setTopicDetail([...data]);
+    data.forEach((topicDetailFromData: TopicInfoType) =>
+      topicHashmap.set(`${topicDetailFromData.id}`, topicDetailFromData),
+    );
+
+    const topicDetailFromData = topicId
+      ?.split(',')
+      .map((number) => topicHashmap.get(number)) as TopicInfoType[];
+
+    if (!topicDetailFromData) return;
+
+    setTopicDetail([...topicDetailFromData]);
   };
 
   const onClickConfirm = () => {
@@ -92,6 +103,8 @@ const SelectedTopic = () => {
               <ul key={topic.id}>
                 {idx !== 0 && <Space size={5} />}
                 <TopicInfo
+                  fullUrl={topicId}
+                  topicId={topicId?.split(',')[idx]}
                   topicParticipant={1}
                   pinNumber={topic.pinCount}
                   topicTitle={topic.name}


### PR DESCRIPTION
<co-author: @kpeel5839> ❤️

<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
같이보기, 핀 생성과 관련된 로직 (라우터 포함)


## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] 토픽이 undefined로 잡히던 오류를 수정한다.
- [x] 토픽이 오름차순으로 정렬되어 체크박스로 선택한 순서와 화면에 보이는 토픽의 순서가 다른 문제를 해결한다.
- [x] 핀을 추가한 후에 해당 핀 페이지로 이동하던 오류를 수정한다. 따라서 이전의 같이보기 페이지로 이동한다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
hash Map 사용

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
#191
<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
