### PR TITLE
[FE]Feature/#205 Toast 컴포넌트 구현 및 기존 alert 대체

### DIFF
--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -6,6 +6,8 @@ import Space from '../common/Space';
 import Logo from './Logo';
 import CoordinatesProvider from '../../context/CoordinatesContext';
 import MarkerProvider from '../../context/MarkerContext';
+import ToastProvider from '../../context/ToastContext';
+import Toast from '../Toast';
 
 type LayoutProps = {
   children: React.ReactNode;
@@ -36,43 +38,46 @@ const Layout = ({ children }: LayoutProps) => {
   }, []);
 
   return (
-    <CoordinatesProvider>
-      <MarkerProvider>
-        <Flex height="100vh" width="100vw">
-          <Flex
-            $flexDirection="column"
-            $minWidth="400px"
-            height="100vh"
-            $backgroundColor="white"
-          >
+    <ToastProvider>
+      <CoordinatesProvider>
+        <MarkerProvider>
+          <Flex height="100vh" width="100vw" position="relative">
             <Flex
               $flexDirection="column"
-              $paddingTop={4}
-              $paddingRight={4}
-              $paddingLeft={4}
+              $minWidth="400px"
+              height="100vh"
+              $backgroundColor="white"
             >
-              <Logo />
-              <Space size={5} />
-              <Input
-                placeholder="검색어를 입력하세요."
-                aria-label="검색어 입력창"
-              />
+              <Flex
+                $flexDirection="column"
+                $paddingTop={4}
+                $paddingRight={4}
+                $paddingLeft={4}
+              >
+                <Logo />
+                <Space size={5} />
+                <Input
+                  placeholder="검색어를 입력하세요."
+                  aria-label="검색어 입력창"
+                />
+              </Flex>
+              <Flex
+                height="calc(100vh - 120px)"
+                $flexDirection="column"
+                overflow="auto"
+                $paddingRight={4}
+                $paddingLeft={4}
+                $paddingBottom={4}
+              >
+                {children}
+              </Flex>
             </Flex>
-            <Flex
-              height="calc(100vh - 120px)"
-              $flexDirection="column"
-              overflow="auto"
-              $paddingRight={4}
-              $paddingLeft={4}
-              $paddingBottom={4}
-            >
-              {children}
-            </Flex>
+            <Map ref={mapContainer} map={map} />
+            <Toast />
           </Flex>
-          <Map ref={mapContainer} map={map} />
-        </Flex>
-      </MarkerProvider>
-    </CoordinatesProvider>
+        </MarkerProvider>
+      </CoordinatesProvider>
+    </ToastProvider>
   );
 };
 

--- a/frontend/src/components/Toast/index.tsx
+++ b/frontend/src/components/Toast/index.tsx
@@ -1,0 +1,71 @@
+import { useContext } from 'react';
+import ReactDOM from 'react-dom';
+import { keyframes, styled } from 'styled-components';
+import { ToastContext } from '../../context/ToastContext';
+import Flex from '../common/Flex';
+import { toastShowTime } from '../../constants';
+
+const asynchronousDelayTime = 50;
+
+const Toast = () => {
+  const { toast } = useContext(ToastContext);
+
+  const root = document.querySelector('#root') as HTMLElement;
+
+  return ReactDOM.createPortal(
+    toast.show && (
+      <Wrapper $justifyContent="center" $alignItems="center" type={toast.type}>
+        {toast.message}
+      </Wrapper>
+    ),
+    root,
+  );
+};
+
+const toastAnimation = keyframes`
+  0% {
+    transform: translate(-50%, 20px);
+    opacity: 0;
+  }
+
+  8% {
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+
+  92%{
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+
+  100% {
+    transform: translate(-50%, 20px);
+    opacity: 0;
+  }
+`;
+
+const Wrapper = styled(Flex)<{ type: string }>`
+  animation: ${toastAnimation} ${toastShowTime + asynchronousDelayTime}ms linear;
+  position: absolute;
+  left: 50%;
+  bottom: ${({ theme }) => theme.spacing[6]};
+  transform: translateX(-50%);
+
+  padding: 0 ${({ theme }) => theme.spacing[4]};
+  height: ${({ theme }) => theme.spacing[6]};
+  border-radius: ${({ theme }) => theme.radius.small};
+  box-shadow: 2px 4px 4px 0px rgba(69, 69, 69, 0.75);
+
+  background-color: ${({ type }) =>
+    ({
+      info: 'rgb(4, 192, 158)',
+      warning: 'rgb(245, 213, 96)',
+      error: 'rgb(222,96,96)',
+    })[type]};
+
+  color: ${({ theme }) => theme.color.white};
+
+  z-index: 2;
+`;
+
+export default Toast;

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -5,6 +5,7 @@ import Share from '../../assets/share.svg';
 import Button from '../common/Button';
 import Space from '../common/Space';
 import useNavigator from '../../hooks/useNavigator';
+import useToast from '../../hooks/useToast';
 
 export interface TopicInfoProps {
   fullUrl?: string;
@@ -26,6 +27,7 @@ const TopicInfo = ({
   topicDescription,
 }: TopicInfoProps) => {
   const { routePage } = useNavigator();
+  const { showToast } = useToast();
 
   const goToNewPin = () => {
     routePage(`/new-pin?topic-id=${topicId}`, fullUrl);
@@ -35,10 +37,9 @@ const TopicInfo = ({
     try {
       const topicUrl = window.location.href.split('?')[0];
       await navigator.clipboard.writeText(topicUrl);
-      alert('토픽 링크가 복사되었습니다.');
+      showToast('info', '토픽 링크가 복사되었습니다.');
     } catch (err) {
-      if (typeof err === 'string') throw new Error(err);
-      throw new Error('[ERROR] clipboard error');
+      showToast('error', '토픽 링크를 복사하는데 실패했습니다.');
     }
   };
 

--- a/frontend/src/components/common/Text/index.ts
+++ b/frontend/src/components/common/Text/index.ts
@@ -15,7 +15,7 @@ export interface TextProps {
   right?: string;
   bottom?: string;
   left?: string;
-  $zIndex?: string;
+  $zIndex?: number;
   overflow?: string;
   $whiteSpace?: string;
   $wordBreak?: string;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const toastShowTime = 3000;

--- a/frontend/src/context/ToastContext.tsx
+++ b/frontend/src/context/ToastContext.tsx
@@ -1,9 +1,15 @@
-import { ReactNode, createContext, useState } from 'react';
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  useState,
+} from 'react';
 import ToastProps from '../types/Toast';
 
 interface ToastContextProps {
   toast: ToastProps;
-  setToast: React.Dispatch<React.SetStateAction<ToastProps>>;
+  setToast: Dispatch<SetStateAction<ToastProps>>;
 }
 
 interface ToastProviderProps {

--- a/frontend/src/context/ToastContext.tsx
+++ b/frontend/src/context/ToastContext.tsx
@@ -1,0 +1,37 @@
+import { ReactNode, createContext, useState } from 'react';
+import ToastProps from '../types/Toast';
+
+interface ToastContextProps {
+  toast: ToastProps;
+  setToast: React.Dispatch<React.SetStateAction<ToastProps>>;
+}
+
+interface ToastProviderProps {
+  children: ReactNode;
+}
+
+export const ToastContext = createContext<ToastContextProps>({
+  toast: { show: false, type: 'info', message: '' },
+  setToast: () => {},
+});
+
+const ToastProvider = ({ children }: ToastProviderProps) => {
+  const [toast, setToast] = useState<ToastProps>({
+    show: false,
+    type: 'info',
+    message: '',
+  });
+
+  return (
+    <ToastContext.Provider
+      value={{
+        toast,
+        setToast,
+      }}
+    >
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+export default ToastProvider;

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,27 @@
+import { useContext } from 'react';
+import ToastProps from '../types/Toast';
+import { ToastContext } from '../context/ToastContext';
+import { toastShowTime } from '../constants';
+
+let timeoutID: null | number = null;
+
+const useToast = () => {
+  const { setToast } = useContext(ToastContext);
+
+  const showToast = (
+    type: ToastProps['type'],
+    message: ToastProps['message'],
+  ) => {
+    if (timeoutID) clearTimeout(timeoutID);
+
+    setToast({ show: true, type, message });
+
+    timeoutID = window.setTimeout(() => {
+      setToast({ show: false, type, message: '' });
+    }, toastShowTime);
+  };
+
+  return { showToast };
+};
+
+export default useToast;

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -15,25 +15,26 @@ import useFormValues from '../hooks/useFormValues';
 import { MarkerContext } from '../context/MarkerContext';
 import { CoordinatesContext } from '../context/CoordinatesContext';
 import { useLocation } from 'react-router-dom';
+import useToast from '../hooks/useToast';
 
 const NewPin = () => {
   const { state: prevUrl } = useLocation();
   const [topic, setTopic] = useState<TopicType | null>(null);
-  const { markers, clickedMarker } = useContext(MarkerContext);
+  const { clickedMarker } = useContext(MarkerContext);
   const { clickedCoordinate, setClickedCoordinate } =
     useContext(CoordinatesContext);
-  const { formValues, setFormValues, onChangeInput } =
-    useFormValues<NewPinValuesType>({
-      topicId: 0,
-      name: '',
-      address: '',
-      description: '',
-      latitude: '',
-      longitude: '',
-      legalDongCode: '',
-      images: [],
-    });
+  const { formValues, onChangeInput } = useFormValues<NewPinValuesType>({
+    topicId: 0,
+    name: '',
+    address: '',
+    description: '',
+    latitude: '',
+    longitude: '',
+    legalDongCode: '',
+    images: [],
+  });
   const { routePage } = useNavigator();
+  const { showToast } = useToast();
   const addressRef = useRef<HTMLInputElement | null>(null);
 
   const goToBack = () => {
@@ -60,6 +61,8 @@ const NewPin = () => {
 
     if (prevUrl.length > 1) routePage(`/topics/${prevUrl}`, [topic!.id]);
     else routePage(`/topics/${topic?.id}`, [topic!.id]);
+
+    showToast('info', `${formValues.name} 핀을 추가하였습니다.`);
 
     // 선택된 마커가 있으면 마커를 지도에서 제거
     if (clickedMarker) {

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -13,11 +13,13 @@ import Box from '../components/common/Box';
 import UpdatedPinDetail from './UpdatedPinDetail';
 import useFormValues from '../hooks/useFormValues';
 import { DefaultPinValuesType } from '../types/FormValues';
+import useToast from '../hooks/useToast';
 
 const PinDetail = ({ pinId }: { pinId: number }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [pin, setPin] = useState<PinType | null>(null);
   const [isEditing, setIsEditing] = useState<boolean>(false);
+  const { showToast } = useToast();
   const { formValues, setFormValues, onChangeInput } =
     useFormValues<DefaultPinValuesType>({
       id: 0,
@@ -61,10 +63,9 @@ const PinDetail = ({ pinId }: { pinId: number }) => {
   const copyContent = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      alert('핀 링크가 복사되었습니다.');
+      showToast('info', '핀 링크가 복사되었습니다.');
     } catch (err) {
-      if (typeof err === 'string') throw new Error(err);
-      throw new Error('[ERROR] clipboard error');
+      showToast('error', '핀 링크를 복사하는데 실패했습니다.');
     }
   };
 

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -16,7 +16,7 @@ import useNavigator from '../hooks/useNavigator';
 const SelectedTopic = () => {
   const { topicId } = useParams();
   const [tagPins, setTagPins] = useState<string[]>([]);
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, _] = useSearchParams();
   const [topicDetail, setTopicDetail] = useState<TopicInfoType[]>([]);
   const [selectedPinId, setSelectedPinId] = useState<number | null>(null);
   const [taggedPinIds, setTaggedPinIds] = useState<number[]>([]);

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -151,7 +151,7 @@ const SelectedTopic = () => {
                 padding={4}
                 $flexDirection="column"
                 $borderLeft={`1px solid ${theme.color.gray}`}
-                $zIndex={99}
+                $zIndex={1}
               >
                 <PinDetail pinId={selectedPinId} />
               </Flex>
@@ -174,7 +174,7 @@ const ToggleButton = styled.button<{ isCollapsed: boolean }>`
   top: 50%;
   left: 800px;
   transform: translateY(-50%);
-  z-index: 99999;
+  z-index: 1;
   height: 80px;
   background-color: #fff;
   padding: 12px;
@@ -188,7 +188,7 @@ const ToggleButton = styled.button<{ isCollapsed: boolean }>`
     transform: rotate(180deg);
     top:45%;
     left: 400px;
-    z-index: 99999;
+    z-index: 1;
     `}
 
   &:hover {

--- a/frontend/src/types/Toast.ts
+++ b/frontend/src/types/Toast.ts
@@ -1,0 +1,5 @@
+export default interface ToastProps {
+  show: boolean;
+  message: string;
+  type: 'info' | 'warning' | 'error';
+}


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
기존 alert를 toast 알림으로 대체합니다. 따라서 Toast 컴포넌트를 구현하고 필요한 것들 (context, custom hook 등) 을 추가합니다.

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] Toast 컴포넌트 구현
- [x] 기존 alert 대체
- [x] Toast 컴포넌트를 사용하기 위해 필요한 것들 구현 (Context 등)
- [x] Toast 컴포넌트를 사용하기 편하게 구현 (Custom hook)

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
추상화 해뒀습니다. 따라서 Toast 필요하신 곳 가셔서
```jsx
const { showToast } = useToast();

showToast(type, message);

// 매개변수 타입
type: 'info' | 'warn' | 'error'; // Toast 배경 색 다름여
message: string // Toast 안에 보여줄 문구
```
위와 같이 사용하시면 끝 Super Easy 하죠?

* 대신 showToast 하는 버튼 연타하면 애니메이션 깨져요. 연타할 상황이 딱히 없어보여서 문제 생기면 그 때 대응하겠습니다. (애니메이션 로직 다 갈아야해서..)

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/41f05bf4-549b-4ef0-96c4-153c5d38f4ae

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
close #205 
<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
