### PR TITLE
[BE] feature/nickname 랜덤 닉네임에 고정 문자열 대신 카카오 닉네임 사용

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
@@ -25,7 +25,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Member extends BaseTimeEntity {
 
+    private static final String DEFAULT_NICKNAME_PREFIX = "모험가";
     private static final int DEFAULT_NICKNAME_SUFFIX_LENGTH = 7;
+    private static final int NICKNAME_MAX_LENGTH = 20;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -81,9 +83,16 @@ public class Member extends BaseTimeEntity {
             Role role,
             OauthId oauthId
     ) {
-        String nickName = nickname + createNicknameSuffix();
+        String nickName = createNickname(nickname);
 
         return Member.of(nickName, email, imageUrl, role, oauthId);
+    }
+
+    private static String createNickname(String nickname) {
+        if (nickname.length() >= NICKNAME_MAX_LENGTH) {
+            return DEFAULT_NICKNAME_PREFIX + createNicknameSuffix();
+        }
+        return nickname + createNicknameSuffix();
     }
 
     private static String createNicknameSuffix() {

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
@@ -89,7 +89,7 @@ public class Member extends BaseTimeEntity {
     }
 
     private static String createNickname(String nickname) {
-        if (nickname.length() >= NICKNAME_MAX_LENGTH) {
+        if (nickname.length() > NICKNAME_MAX_LENGTH - DEFAULT_NICKNAME_SUFFIX_LENGTH) {
             return DEFAULT_NICKNAME_PREFIX + createNicknameSuffix();
         }
         return nickname + createNicknameSuffix();

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
@@ -25,7 +25,6 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Member extends BaseTimeEntity {
 
-    private static final String DEFAULT_NICKNAME_PREFIX = "모험가";
     private static final int DEFAULT_NICKNAME_SUFFIX_LENGTH = 7;
 
     @Id
@@ -76,12 +75,13 @@ public class Member extends BaseTimeEntity {
     }
 
     public static Member ofRandomNickname(
+            String nickname,
             String email,
             String imageUrl,
             Role role,
             OauthId oauthId
     ) {
-        String nickName = DEFAULT_NICKNAME_PREFIX + createNicknameSuffix();
+        String nickName = nickname + createNicknameSuffix();
 
         return Member.of(nickName, email, imageUrl, role, oauthId);
     }

--- a/backend/src/main/java/com/mapbefine/mapbefine/oauth/domain/OauthMember.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/oauth/domain/OauthMember.java
@@ -8,31 +8,41 @@ import lombok.Getter;
 @Getter
 public class OauthMember {
 
+    private String nickname;
     private String email;
     private String profileImageUrl;
     private OauthId oauthId;
 
     private OauthMember(
+            String nickname,
             String email,
             String profileImageUrl,
             OauthId oauthId
     ) {
+        this.nickname = nickname;
         this.email = email;
         this.profileImageUrl = profileImageUrl;
         this.oauthId = oauthId;
     }
 
     public static OauthMember of(
+            String nickname,
             String email,
             String profileImageUrl,
             Long oauthServerId,
             OauthServerType oauthServerType
     ) {
-        return new OauthMember(email, profileImageUrl, new OauthId(oauthServerId, oauthServerType));
+        return new OauthMember(
+                nickname,
+                email,
+                profileImageUrl,
+                new OauthId(oauthServerId, oauthServerType)
+        );
     }
 
     public Member toRegisterMember() {
         return Member.ofRandomNickname(
+                nickname,
                 email,
                 profileImageUrl,
                 Role.USER,

--- a/backend/src/main/java/com/mapbefine/mapbefine/oauth/domain/kakao/dto/KakaoMemberResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/oauth/domain/kakao/dto/KakaoMemberResponse.java
@@ -17,6 +17,7 @@ public record KakaoMemberResponse(
 
     public OauthMember extract() {
         return OauthMember.of(
+                kakaoAccount().profile.nickname,
                 kakaoAccount().email,
                 kakaoAccount().profile.profileImageUrl,
                 id,

--- a/backend/src/test/java/com/mapbefine/mapbefine/oauth/application/OauthServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/oauth/application/OauthServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 class OauthServiceTest {
 
     private static final OauthMember oauthMember = OauthMember.of(
+            "닉네임",
             "yshert@naver.com",
             "https://map-befine-official.github.io/favicon.png",
             Long.MAX_VALUE,

--- a/backend/src/test/java/com/mapbefine/mapbefine/oauth/application/OauthServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/oauth/application/OauthServiceTest.java
@@ -28,7 +28,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 class OauthServiceTest {
 
     private static final OauthMember oauthMember = OauthMember.of(
-            "닉네임",
+            "12345678901234567890",
             "yshert@naver.com",
             "https://map-befine-official.github.io/favicon.png",
             Long.MAX_VALUE,
@@ -83,6 +83,7 @@ class OauthServiceTest {
     void getAuthCodeRequestUrl_success() {
         // when
         String url = oauthService.getAuthCodeRequestUrl(OauthServerType.KAKAO);
+        System.out.println(oauthMember.toRegisterMember().getMemberInfo().getNickName());
 
         // then
         assertThat(url).isEqualTo("https://kauth.kakao.com/oauth/authorize?"

--- a/backend/src/test/java/com/mapbefine/mapbefine/oauth/domain/OauthMemberTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/oauth/domain/OauthMemberTest.java
@@ -8,10 +8,10 @@ import org.junit.jupiter.api.Test;
 class OauthMemberTest {
 
     @Test
-    @DisplayName("소셜 로그인 닉네임의 길이가 20자 이상이면 기본 랜덤 닉네임을 부여한다.")
+    @DisplayName("소셜 로그인 닉네임의 길이가 13자 초과이면 기본 랜덤 닉네임을 부여한다.")
     void toRegisterMember() {
         OauthMember oauthMember = OauthMember.of(
-                "일이삼사오육칠팔구십일이삼사오육칠팔구십",
+                "일이삼사오육칠팔구십일이삼사",
                 "member@gmail.com",
                 "https://image.url",
                 1L,

--- a/backend/src/test/java/com/mapbefine/mapbefine/oauth/domain/OauthMemberTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/oauth/domain/OauthMemberTest.java
@@ -1,0 +1,28 @@
+package com.mapbefine.mapbefine.oauth.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OauthMemberTest {
+
+    @Test
+    @DisplayName("소셜 로그인 닉네임의 길이가 20자 이상이면 기본 랜덤 닉네임을 부여한다.")
+    void toRegisterMember() {
+        OauthMember oauthMember = OauthMember.of(
+                "일이삼사오육칠팔구십일이삼사오육칠팔구십",
+                "member@gmail.com",
+                "https://image.url",
+                1L,
+                OauthServerType.KAKAO
+        );
+
+        String expected = oauthMember.toRegisterMember()
+                .getMemberInfo()
+                .getNickName();
+
+        System.out.println(expected);
+        assertThat(expected).contains("모험가");
+    }
+}


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
OauthMember 관련

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
랜덤 닉네임에 고정 문자열을 사용함으로 인해 해당 사용자를 식별하기 어려워서,  
닉네임 수정 기능 적용 전까지 카카오 닉네임+UUID를 랜덤 닉네임으로 사용하도록 수정했습니다.
카카오 닉네임이 13자 초과일 경우 기본 랜덤 닉네임(모험가+UUID)을 부여합니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
