### PR TITLE
[FE] Feature/#382 반응형 대응

### DIFF
--- a/.github/workflows/fe-merge-dev.yml
+++ b/.github/workflows/fe-merge-dev.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
   pull_request:
-    branches: [develop]
+    branches: [develop-FE]
     types: [closed]
     paths: frontend/**
 

--- a/.github/workflows/fe-pull-request.yml
+++ b/.github/workflows/fe-pull-request.yml
@@ -29,10 +29,8 @@ jobs:
       - name: Run Jest test
         run: npm run test
 
-      - name: Start npm
-        run: npm run dev
-
       - name: Run Cypress
         uses: cypress-io/github-action@v5
         with:
-          start: npm run cypress
+          working-directory: frontend
+          start: npm run dev

--- a/.github/workflows/fe-pull-request.yml
+++ b/.github/workflows/fe-pull-request.yml
@@ -11,7 +11,7 @@ defaults:
     working-directory: ./frontend
 
 jobs:
-  jest:
+  jest_cypress:
     runs-on: ubuntu-22.04
 
     steps:

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
+    defaultCommandTimeout: 10000,
   },
 });

--- a/frontend/cypress/e2e/mapbefine.cy.ts
+++ b/frontend/cypress/e2e/mapbefine.cy.ts
@@ -69,7 +69,7 @@ describe('토픽 상세 페이지', () => {
         if (index === 0) $el.click();
       });
 
-    cy.wait(2000);
+    cy.wait(3000);
 
     cy.get('span').each(($el, index) => {
       if (index === 6) $el.click();

--- a/frontend/cypress/e2e/mapbefine.cy.ts
+++ b/frontend/cypress/e2e/mapbefine.cy.ts
@@ -75,6 +75,8 @@ describe('토픽 상세 페이지', () => {
       if (index === 6) $el.click();
     });
 
+    cy.get('[data-cy="pin-detail"]').scrollTo('bottom');
+
     cy.contains('내 지도에 저장하기').should('be.visible');
   });
 
@@ -90,6 +92,8 @@ describe('토픽 상세 페이지', () => {
     cy.get('span').each(($el, index) => {
       if (index === 6) $el.click();
     });
+
+    cy.get('[data-cy="pin-detail"]').scrollTo('bottom');
 
     cy.contains('내 지도에 저장하기').click();
 

--- a/frontend/cypress/e2e/mapbefine.cy.ts
+++ b/frontend/cypress/e2e/mapbefine.cy.ts
@@ -69,7 +69,7 @@ describe('토픽 상세 페이지', () => {
         if (index === 0) $el.click();
       });
 
-    cy.wait(1000);
+    cy.wait(2000);
 
     cy.get('span').each(($el, index) => {
       if (index === 6) $el.click();
@@ -87,7 +87,7 @@ describe('토픽 상세 페이지', () => {
         if (index === 0) $el.click();
       });
 
-    cy.wait(1000);
+    cy.wait(2000);
 
     cy.get('span').each(($el, index) => {
       if (index === 6) $el.click();

--- a/frontend/src/components/InputContainer/index.tsx
+++ b/frontend/src/components/InputContainer/index.tsx
@@ -111,7 +111,7 @@ const InputContainer = ({
 };
 const ErrorText = styled.span`
   display: block;
-  height: 20px;
+  min-height: 20px;
   font-size: 14px;
   color: #ff4040;
 `;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -185,7 +185,7 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
 
 const Wrapper = styled.nav<{ $layoutWidth: '100vw' | '372px' }>`
   width: 100%;
-  height: 64px;
+  min-height: 64px;
   display: flex;
   justify-content: ${({ $layoutWidth }) =>
     $layoutWidth === '100vw' ? 'center' : 'space-around'};
@@ -193,7 +193,7 @@ const Wrapper = styled.nav<{ $layoutWidth: '100vw' | '372px' }>`
   background-color: ${({ theme }) => theme.color.white};
   z-index: 2;
 
-  @media (max-width: 480px) {
+  @media (max-width: 1076px) {
     justify-content: space-around;
   }
 `;
@@ -212,7 +212,7 @@ const IconWrapper = styled.div<{ $layoutWidth: '100vw' | '372px' }>`
     margin-right: 0;
   }
 
-  @media (max-width: 480px) {
+  @media (max-width: 1076px) {
     margin-right: 0;
   }
 `;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -190,6 +190,8 @@ const Wrapper = styled.nav<{ $layoutWidth: '100vw' | '372px' }>`
   justify-content: ${({ $layoutWidth }) =>
     $layoutWidth === '100vw' ? 'center' : 'space-around'};
   align-items: center;
+  background-color: ${({ theme }) => theme.color.white};
+  z-index: 2;
 
   @media (max-width: 480px) {
     justify-content: space-around;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -198,6 +198,7 @@ const Wrapper = styled.nav<{
   align-items: center;
   background-color: ${({ theme }) => theme.color.white};
   z-index: 2;
+  box-shadow: 0 -1px 8px rgba(0, 0, 0, 0.3);
 
   @media (max-width: 1076px) {
     justify-content: space-around;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -75,6 +75,7 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
   return (
     <Wrapper $layoutWidth={$layoutWidth}>
       <IconWrapper
+        $layoutWidth={$layoutWidth}
         onClick={goToHome}
         tabIndex={10}
         ref={firstElement}
@@ -90,9 +91,8 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
         </Text>
       </IconWrapper>
 
-      <IconSpace size={7} $layoutWidth={$layoutWidth} />
-
       <IconWrapper
+        $layoutWidth={$layoutWidth}
         onClick={goToSeeTogether}
         tabIndex={10}
         ref={secondElement}
@@ -109,9 +109,8 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
         <SeeTogetherCounter />
       </IconWrapper>
 
-      <IconSpace size={7} $layoutWidth={$layoutWidth} />
-
       <IconWrapper
+        $layoutWidth={$layoutWidth}
         onClick={onClickAddMapOrPin}
         tabIndex={10}
         ref={thirdElement}
@@ -127,9 +126,8 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
         </Text>
       </IconWrapper>
 
-      <IconSpace size={7} $layoutWidth={$layoutWidth} />
-
       <IconWrapper
+        $layoutWidth={$layoutWidth}
         onClick={goToFavorite}
         tabIndex={11}
         ref={fourElement}
@@ -145,9 +143,8 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
         </Text>
       </IconWrapper>
 
-      <IconSpace size={7} $layoutWidth={$layoutWidth} />
-
       <IconWrapper
+        $layoutWidth={$layoutWidth}
         onClick={goToProfile}
         tabIndex={11}
         ref={FifthElement}
@@ -193,28 +190,33 @@ const Wrapper = styled.nav<{ $layoutWidth: '100vw' | '372px' }>`
   justify-content: ${({ $layoutWidth }) =>
     $layoutWidth === '100vw' ? 'center' : 'space-around'};
   align-items: center;
+
+  @media (max-width: 480px) {
+    justify-content: space-around;
+  }
 `;
 
-const IconWrapper = styled.div`
+const IconWrapper = styled.div<{ $layoutWidth: '100vw' | '372px' }>`
   position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   width: 52px;
   cursor: pointer;
-`;
+  margin-right: ${({ $layoutWidth }) =>
+    $layoutWidth === '100vw' ? '48px' : '0'};
 
-const IconSpace = styled(Space)<{ $layoutWidth: '100vw' | '372px' }>`
-  display: ${({ $layoutWidth }) =>
-    $layoutWidth === '100vw' ? 'block' : 'none'};
+  &:last-of-type {
+    margin-right: 0;
+  }
+
+  @media (max-width: 480px) {
+    margin-right: 0;
+  }
 `;
 
 const RouteButton = styled(Button)`
   box-shadow: 2px 4px 4px rgba(0, 0, 0, 0.5);
 `;
 
-const ModalWrapper = styled(Flex)`
-  width: 100%;
-  height: 100%;
-`;
 export default Navbar;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 import useNavigator from '../../hooks/useNavigator';
 import Flex from '../common/Flex';
 import Button from '../common/Button';
@@ -73,7 +73,10 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
   };
 
   return (
-    <Wrapper $layoutWidth={$layoutWidth}>
+    <Wrapper
+      $isAddPage={navbarHighlights.addMapOrPin}
+      $layoutWidth={$layoutWidth}
+    >
       <IconWrapper
         $layoutWidth={$layoutWidth}
         onClick={goToHome}
@@ -183,7 +186,10 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
   );
 };
 
-const Wrapper = styled.nav<{ $layoutWidth: '100vw' | '372px' }>`
+const Wrapper = styled.nav<{
+  $isAddPage: boolean;
+  $layoutWidth: '100vw' | '372px';
+}>`
   width: 100%;
   min-height: 64px;
   display: flex;
@@ -192,6 +198,13 @@ const Wrapper = styled.nav<{ $layoutWidth: '100vw' | '372px' }>`
   align-items: center;
   background-color: ${({ theme }) => theme.color.white};
   z-index: 2;
+
+  ${({ $isAddPage }) =>
+    $isAddPage &&
+    css`
+      position: fixed;
+      bottom: 0;
+    `}
 
   @media (max-width: 1076px) {
     justify-content: space-around;

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -191,7 +191,7 @@ const Wrapper = styled.nav<{
   $layoutWidth: '100vw' | '372px';
 }>`
   width: 100%;
-  min-height: 64px;
+  min-height: 56px;
   display: flex;
   justify-content: ${({ $layoutWidth }) =>
     $layoutWidth === '100vw' ? 'center' : 'space-around'};
@@ -199,15 +199,15 @@ const Wrapper = styled.nav<{
   background-color: ${({ theme }) => theme.color.white};
   z-index: 2;
 
-  ${({ $isAddPage }) =>
-    $isAddPage &&
-    css`
-      position: fixed;
-      bottom: 0;
-    `}
-
   @media (max-width: 1076px) {
     justify-content: space-around;
+
+    ${({ $isAddPage }) =>
+      $isAddPage &&
+      css`
+        position: fixed;
+        bottom: 0;
+      `}
   }
 `;
 

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -12,7 +12,7 @@ import SeeTogetherProvider from '../../context/SeeTogetherContext';
 import Space from '../common/Space';
 import Navbar from './Navbar';
 import ModalProvider from '../../context/ModalContext';
-import NavbarHighlightsProvider from '../../context/NavbarHighlightsContext';
+import { NavbarHighlightsContext } from '../../context/NavbarHighlightsContext';
 import TagProvider from '../../context/TagContext';
 import Box from '../common/Box';
 
@@ -31,7 +31,7 @@ const Layout = ({ children }: LayoutProps) => {
   const { Tmapv3 } = window;
   const mapContainer = useRef(null);
   const { width } = useContext(LayoutWidthContext);
-  const isLogined = localStorage.getItem('userToken');
+  const { navbarHighlights } = useContext(NavbarHighlightsContext);
 
   const [map, setMap] = useState(null);
 
@@ -49,50 +49,52 @@ const Layout = ({ children }: LayoutProps) => {
   return (
     <ToastProvider>
       <ModalProvider>
-        <NavbarHighlightsProvider>
-          <CoordinatesProvider>
-            <MarkerProvider>
-              <SeeTogetherProvider>
-                <TagProvider>
-                  <MediaWrapper $mediaWidth={width}>
-                    <LayoutFlex
+        <CoordinatesProvider>
+          <MarkerProvider>
+            <SeeTogetherProvider>
+              <TagProvider>
+                <MediaWrapper
+                  $isAddPage={navbarHighlights.addMapOrPin}
+                  $mediaWidth={width}
+                >
+                  <LayoutFlex
+                    $flexDirection="column"
+                    $minWidth={width}
+                    height="100vh"
+                    $backgroundColor="white"
+                    $mediaWidth={width}
+                  >
+                    <LogoWrapper $mediaWidth={width}>
+                      <Box>
+                        <Logo />
+                        <Space size={2} />
+                      </Box>
+                    </LogoWrapper>
+                    <Flex
+                      height="calc(100vh - 48px)"
                       $flexDirection="column"
-                      $minWidth={width}
-                      height="100vh"
-                      $backgroundColor="white"
-                      $mediaWidth={width}
+                      overflow="auto"
+                      padding="0 20px 20px 20px"
                     >
-                      <LogoWrapper $mediaWidth={width}>
-                        <Box>
-                          <Logo />
-                          <Space size={2} />
-                        </Box>
-                      </LogoWrapper>
-                      <Flex
-                        height="calc(100vh - 48px)"
-                        $flexDirection="column"
-                        overflow="auto"
-                        padding="0 20px 20px 20px"
-                      >
-                        {children}
-                      </Flex>
-                      <Navbar $layoutWidth={width} />
-                    </LayoutFlex>
-
-                    <Map ref={mapContainer} map={map} $minWidth={width} />
-                  </MediaWrapper>
-                  <Toast />
-                </TagProvider>
-              </SeeTogetherProvider>
-            </MarkerProvider>
-          </CoordinatesProvider>
-        </NavbarHighlightsProvider>
+                      {children}
+                    </Flex>
+                    <Navbar $layoutWidth={width} />
+                  </LayoutFlex>
+                  <Map ref={mapContainer} map={map} $minWidth={width} />
+                </MediaWrapper>
+                <Toast />
+              </TagProvider>
+            </SeeTogetherProvider>
+          </MarkerProvider>
+        </CoordinatesProvider>
       </ModalProvider>
     </ToastProvider>
   );
 };
 
-const LogoWrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
+const LogoWrapper = styled.section<{
+  $mediaWidth: '372px' | '100vw';
+}>`
   width: 372px;
   display: flex;
   padding: 12px 20px 0 20px;
@@ -110,14 +112,19 @@ const LogoWrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
   }
 `;
 
-const MediaWrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
+const MediaWrapper = styled.section<{
+  $isAddPage: boolean;
+  $mediaWidth: '372px' | '100vw';
+}>`
   display: flex;
   width: 100vw;
   overflow: hidden;
 
   @media (max-width: 1076px) {
-    flex-direction: ${({ $mediaWidth }) =>
-      $mediaWidth === '372px' && 'column-reverse'};
+    flex-direction: ${({ $isAddPage, $mediaWidth }) => {
+      if ($isAddPage) return 'column';
+      if ($mediaWidth === '372px') return 'column-reverse';
+    }};
   }
 `;
 
@@ -126,14 +133,8 @@ const LayoutFlex = styled(Flex)<{ $mediaWidth: '372px' | '100vw' }>`
 
   @media (max-width: 1076px) {
     height: ${({ $mediaWidth }) => $mediaWidth === '372px' && '50vh'};
+    transition: none;
   }
-`;
-
-const MyInfoImg = styled.img`
-  width: 40px;
-  height: 40px;
-
-  border-radius: 50%;
 `;
 
 export default Layout;

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -6,7 +6,7 @@ import CoordinatesProvider from '../../context/CoordinatesContext';
 import MarkerProvider from '../../context/MarkerContext';
 import ToastProvider from '../../context/ToastContext';
 import Toast from '../Toast';
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 import { LayoutWidthContext } from '../../context/LayoutWidthContext';
 import SeeTogetherProvider from '../../context/SeeTogetherContext';
 import Space from '../common/Space';
@@ -14,7 +14,6 @@ import Navbar from './Navbar';
 import ModalProvider from '../../context/ModalContext';
 import NavbarHighlightsProvider from '../../context/NavbarHighlightsContext';
 import TagProvider from '../../context/TagContext';
-import InfoDefalutImg from '../../assets/InfoDefalutImg.svg';
 import Box from '../common/Box';
 
 type LayoutProps = {
@@ -33,10 +32,6 @@ const Layout = ({ children }: LayoutProps) => {
   const mapContainer = useRef(null);
   const { width } = useContext(LayoutWidthContext);
   const isLogined = localStorage.getItem('userToken');
-
-  const loginButtonClick = () => {
-    window.location.href = 'https://mapbefine.kro.kr/api/oauth/kakao';
-  };
 
   const [map, setMap] = useState(null);
 
@@ -59,24 +54,22 @@ const Layout = ({ children }: LayoutProps) => {
             <MarkerProvider>
               <SeeTogetherProvider>
                 <TagProvider>
-                  <Flex height="100vh" width="100vw" overflow="hidden">
+                  <MediaWrapper $mediaWidth={width}>
                     <LayoutFlex
                       $flexDirection="column"
                       $minWidth={width}
                       height="100vh"
                       $backgroundColor="white"
+                      $mediaWidth={width}
                     >
-                      <Flex
-                        $justifyContent="space-between"
-                        padding="20px 20px 0 20px"
-                      >
+                      <LogoWrapper $mediaWidth={width}>
                         <Box>
                           <Logo />
-                          <Space size={3} />
+                          <Space size={2} />
                         </Box>
-                      </Flex>
+                      </LogoWrapper>
                       <Flex
-                        height="calc(100vh - 52px)"
+                        height="calc(100vh - 48px)"
                         $flexDirection="column"
                         overflow="auto"
                         padding="0 20px 20px 20px"
@@ -84,10 +77,11 @@ const Layout = ({ children }: LayoutProps) => {
                         {children}
                       </Flex>
                       <Navbar $layoutWidth={width} />
-                      <Toast />
                     </LayoutFlex>
+
                     <Map ref={mapContainer} map={map} $minWidth={width} />
-                  </Flex>
+                  </MediaWrapper>
+                  <Toast />
                 </TagProvider>
               </SeeTogetherProvider>
             </MarkerProvider>
@@ -98,8 +92,41 @@ const Layout = ({ children }: LayoutProps) => {
   );
 };
 
-const LayoutFlex = styled(Flex)`
+const LogoWrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
+  width: 372px;
+  display: flex;
+  padding: 12px 20px 0 20px;
+
+  @media (max-width: 1076px) {
+    ${({ $mediaWidth }) =>
+      $mediaWidth === '372px' &&
+      css`
+        width: 100vw;
+        background-color: white;
+        position: fixed;
+        top: 0;
+        z-index: 1;
+      `};
+  }
+`;
+
+const MediaWrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
+  display: flex;
+  width: 100vw;
+  overflow: hidden;
+
+  @media (max-width: 1076px) {
+    flex-direction: ${({ $mediaWidth }) =>
+      $mediaWidth === '372px' && 'column-reverse'};
+  }
+`;
+
+const LayoutFlex = styled(Flex)<{ $mediaWidth: '372px' | '100vw' }>`
   transition: all ease 0.3s;
+
+  @media (max-width: 1076px) {
+    height: ${({ $mediaWidth }) => $mediaWidth === '372px' && '50vh'};
+  }
 `;
 
 const MyInfoImg = styled.img`

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -55,16 +55,16 @@ const Layout = ({ children }: LayoutProps) => {
               <TagProvider>
                 <MediaWrapper
                   $isAddPage={navbarHighlights.addMapOrPin}
-                  $mediaWidth={width}
+                  $layoutWidth={width}
                 >
                   <LayoutFlex
                     $flexDirection="column"
                     $minWidth={width}
                     height="100vh"
                     $backgroundColor="white"
-                    $mediaWidth={width}
+                    $layoutWidth={width}
                   >
-                    <LogoWrapper $mediaWidth={width}>
+                    <LogoWrapper $layoutWidth={width}>
                       <Box>
                         <Logo />
                         <Space size={2} />
@@ -93,15 +93,15 @@ const Layout = ({ children }: LayoutProps) => {
 };
 
 const LogoWrapper = styled.section<{
-  $mediaWidth: '372px' | '100vw';
+  $layoutWidth: '372px' | '100vw';
 }>`
   width: 372px;
   display: flex;
   padding: 12px 20px 0 20px;
 
   @media (max-width: 1076px) {
-    ${({ $mediaWidth }) =>
-      $mediaWidth === '372px' &&
+    ${({ $layoutWidth }) =>
+      $layoutWidth === '372px' &&
       css`
         width: 100vw;
         background-color: white;
@@ -114,25 +114,25 @@ const LogoWrapper = styled.section<{
 
 const MediaWrapper = styled.section<{
   $isAddPage: boolean;
-  $mediaWidth: '372px' | '100vw';
+  $layoutWidth: '372px' | '100vw';
 }>`
   display: flex;
   width: 100vw;
   overflow: hidden;
 
   @media (max-width: 1076px) {
-    flex-direction: ${({ $isAddPage, $mediaWidth }) => {
+    flex-direction: ${({ $isAddPage, $layoutWidth }) => {
       if ($isAddPage) return 'column';
-      if ($mediaWidth === '372px') return 'column-reverse';
+      if ($layoutWidth === '372px') return 'column-reverse';
     }};
   }
 `;
 
-const LayoutFlex = styled(Flex)<{ $mediaWidth: '372px' | '100vw' }>`
+const LayoutFlex = styled(Flex)<{ $layoutWidth: '372px' | '100vw' }>`
   transition: all ease 0.3s;
 
   @media (max-width: 1076px) {
-    height: ${({ $mediaWidth }) => $mediaWidth === '372px' && '50vh'};
+    height: ${({ $layoutWidth }) => $layoutWidth === '372px' && '50vh'};
     transition: none;
   }
 `;

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -40,6 +40,10 @@ const MapFlex = styled(Flex)`
         $minWidth === '100vw' ? '0' : 'calc(100vw - 400px)'};
     }
   }
+
+  @media (max-width: 1076px) {
+    max-height: 50vh;
+  }
 `;
 
 export default forwardRef(Map);

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -75,27 +75,6 @@ const Modal = ({
     root,
   );
 };
-const Wrapper = styled.div<ModalWrapperType>`
-  width: ${({ width }) => width || '400px'};
-  height: ${({ height }) => height || '400px'};
-  ${({ position }) => getModalPosition(position)};
-  top: ${({ top }) => top && top};
-  left: ${({ left }) => left && left};
-  z-index: 2;
-
-  @media (max-width: 1076px) {
-    left: 50%;
-  }
-`;
-
-const WrapperDimmed = styled.div<{ $dimmedColor: string }>`
-  width: 100%;
-  height: 100%;
-  position: fixed;
-  top: 0;
-  background-color: ${({ $dimmedColor }) => $dimmedColor};
-  z-index: 2;
-`;
 
 const translateModalAnimation = keyframes`
   from {
@@ -117,7 +96,7 @@ const openModalAnimation = keyframes`
   }
 `;
 
-const getModalPosition = (position: 'center' | 'bottom' | 'absolute') => {
+const getModalPosition = (position: 'center' | 'bottom') => {
   switch (position) {
     case 'center':
       return css`
@@ -142,5 +121,32 @@ const getModalPosition = (position: 'center' | 'bottom' | 'absolute') => {
       `;
   }
 };
+
+const Wrapper = styled.div<ModalWrapperType>`
+  width: ${({ width }) => width || '400px'};
+  height: ${({ height }) => height || '400px'};
+  ${({ position }) => getModalPosition(position)};
+  top: ${({ top }) => top && top};
+  left: ${({ left }) => left && left};
+  z-index: 2;
+
+  @media (max-width: 1076px) {
+    left: 50%;
+  }
+
+  @media (max-width: 744px) {
+    ${getModalPosition('bottom')};
+    width: 100%;
+  }
+`;
+
+const WrapperDimmed = styled.div<{ $dimmedColor: string }>`
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  background-color: ${({ $dimmedColor }) => $dimmedColor};
+  z-index: 2;
+`;
 
 export default Modal;

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -82,6 +82,10 @@ const Wrapper = styled.div<ModalWrapperType>`
   top: ${({ top }) => top && top};
   left: ${({ left }) => left && left};
   z-index: 2;
+
+  @media (max-width: 1076px) {
+    left: 50%;
+  }
 `;
 
 const WrapperDimmed = styled.div<{ $dimmedColor: string }>`

--- a/frontend/src/components/Modal/index.tsx
+++ b/frontend/src/components/Modal/index.tsx
@@ -130,10 +130,6 @@ const Wrapper = styled.div<ModalWrapperType>`
   left: ${({ left }) => left && left};
   z-index: 2;
 
-  @media (max-width: 1076px) {
-    left: 50%;
-  }
-
   @media (max-width: 744px) {
     ${getModalPosition('bottom')};
     width: 100%;

--- a/frontend/src/components/ModalMyTopicList/addToMyTopicList.tsx
+++ b/frontend/src/components/ModalMyTopicList/addToMyTopicList.tsx
@@ -6,6 +6,7 @@ import { ModalContext } from '../../context/ModalContext';
 import useToast from '../../hooks/useToast';
 import useGet from '../../apiHooks/useGet';
 import usePost from '../../apiHooks/usePost';
+import Space from '../common/Space';
 
 interface OnClickDesignatedProps {
   topicId: number;
@@ -61,25 +62,28 @@ const AddToMyTopicList = ({ pin }: any) => {
   if (!myTopics) return <></>;
 
   return (
-    <ModalMyTopicListWrapper>
-      {myTopics.map((topic) => (
-        <Fragment key={topic.id}>
-          <TopicCard
-            cardType="modal"
-            id={topic.id}
-            image={topic.image}
-            name={topic.name}
-            creator={topic.creator}
-            updatedAt={topic.updatedAt}
-            pinCount={topic.pinCount}
-            onClickDesignated={addPinToTopic}
-            bookmarkCount={topic.bookmarkCount}
-            isBookmarked={topic.isBookmarked}
-            isInAtlas={topic.isInAtlas}
-          />
-        </Fragment>
-      ))}
-    </ModalMyTopicListWrapper>
+    <>
+      <ModalMyTopicListWrapper>
+        {myTopics.map((topic) => (
+          <Fragment key={topic.id}>
+            <TopicCard
+              cardType="modal"
+              id={topic.id}
+              image={topic.image}
+              name={topic.name}
+              creator={topic.creator}
+              updatedAt={topic.updatedAt}
+              pinCount={topic.pinCount}
+              onClickDesignated={addPinToTopic}
+              bookmarkCount={topic.bookmarkCount}
+              isBookmarked={topic.isBookmarked}
+              isInAtlas={topic.isInAtlas}
+            />
+          </Fragment>
+        ))}
+      </ModalMyTopicListWrapper>
+      <Space size={5} />
+    </>
   );
 };
 
@@ -89,6 +93,12 @@ const ModalMyTopicListWrapper = styled.ul`
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
+
+  @media (max-width: 744px) {
+    width: 100%;
+    justify-content: center;
+    margin-bottom: 48px;
+  }
 `;
 
 export default AddToMyTopicList;

--- a/frontend/src/components/ModalMyTopicList/index.tsx
+++ b/frontend/src/components/ModalMyTopicList/index.tsx
@@ -74,6 +74,12 @@ const ModalMyTopicListWrapper = styled.ul`
   display: flex;
   flex-wrap: wrap;
   gap: 20px;
+
+  @media (max-width: 744px) {
+    width: 100%;
+    justify-content: center;
+    margin-bottom: 48px;
+  }
 `;
 
 export default ModalMyTopicList;

--- a/frontend/src/components/MyInfo/index.tsx
+++ b/frontend/src/components/MyInfo/index.tsx
@@ -37,7 +37,7 @@ const MyInfo = () => {
       $alignItems="center"
     >
       <MyInfoImg src={user.imageUrl} />
-      <Space size={7} />
+      <Space size={5} />
       <Box>
         <Text color="black" $fontSize="medium" $fontWeight="bold">
           {user.nickName}

--- a/frontend/src/components/PinsOfTopic/index.tsx
+++ b/frontend/src/components/PinsOfTopic/index.tsx
@@ -1,3 +1,4 @@
+import { styled } from 'styled-components';
 import { DEFAULT_TOPIC_IMAGE } from '../../constants';
 import { TopicDetailProps } from '../../types/Topic';
 import PinPreview from '../PinPreview';
@@ -21,7 +22,7 @@ const PinsOfTopic = ({
   setTopicsFromServer,
 }: PinsOfTopicProps) => {
   return (
-    <ul>
+    <Wrapper>
       <TopicInfo
         fullUrl={String(topicId)}
         topicId={topicId}
@@ -51,8 +52,10 @@ const PinsOfTopic = ({
           />
         </li>
       ))}
-    </ul>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.ul``;
 
 export default PinsOfTopic;

--- a/frontend/src/components/PullPin/index.tsx
+++ b/frontend/src/components/PullPin/index.tsx
@@ -21,20 +21,11 @@ const PullPin = ({
   if (tags.length === 0) return <></>;
 
   return (
-    <Wrapper
-      width="332px"
-      $flexDirection="column"
-      $alignItems="center"
-      $justifyContent="center"
-      $backgroundColor="white"
-      position="fixed"
-      $borderRadius="small"
-      $zIndex={1}
-    >
+    <Wrapper>
       <Space size={6} />
       <Flex
         $flexDirection="row"
-        $justifyContent="left"
+        $justifyContent="center"
         $flexWrap="wrap"
         $gap="12px 12px"
       >
@@ -96,8 +87,25 @@ const PullPin = ({
   );
 };
 
-const Wrapper = styled(Flex)`
-  border-bottom: 2px solid ${({ theme }) => theme.color.black};
+const Wrapper = styled.section`
+  width: 332px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: white;
+  position: fixed;
+  border-radius: ${({ theme }) => theme.radius.small};
+  z-index: 1;
+  border-bottom: 4px solid ${({ theme }) => theme.color.black};
+
+  @media (max-width: 1076px) {
+    width: calc(50vw - 40px);
+  }
+
+  @media (max-width: 774px) {
+    width: 332px;
+  }
 `;
 
 export default PullPin;

--- a/frontend/src/components/PullPin/index.tsx
+++ b/frontend/src/components/PullPin/index.tsx
@@ -103,7 +103,11 @@ const Wrapper = styled.section`
     width: calc(50vw - 40px);
   }
 
-  @media (max-width: 774px) {
+  @media (max-width: 744px) {
+    width: calc(100vw - 40px);
+  }
+
+  @media (max-width: 372px) {
     width: 332px;
   }
 `;

--- a/frontend/src/components/Toast/index.tsx
+++ b/frontend/src/components/Toast/index.tsx
@@ -14,7 +14,12 @@ const Toast = () => {
 
   return ReactDOM.createPortal(
     toast.show && (
-      <Wrapper $justifyContent="center" $alignItems="center" type={toast.type} role="alert">
+      <Wrapper
+        $justifyContent="center"
+        $alignItems="center"
+        type={toast.type}
+        role="alert"
+      >
         {toast.message}
       </Wrapper>
     ),
@@ -62,6 +67,10 @@ const Wrapper = styled(Flex)<{ type: string }>`
   color: ${({ theme }) => theme.color.white};
 
   z-index: 2;
+
+  @media (max-width: 588px) {
+    width: 80%;
+  }
 `;
 
 export default Toast;

--- a/frontend/src/components/TopicCardContainer/index.tsx
+++ b/frontend/src/components/TopicCardContainer/index.tsx
@@ -113,10 +113,9 @@ const PointerText = styled(Text)`
 
 const TopicsWrapper = styled.ul`
   display: flex;
+  justify-content: center;
   flex-wrap: wrap;
   gap: 20px;
-  height: 300px;
-  overflow: hidden;
 `;
 
 export default TopicCardContainer;

--- a/frontend/src/components/TopicCardList/index.tsx
+++ b/frontend/src/components/TopicCardList/index.tsx
@@ -86,7 +86,6 @@ const EmptyWrapper = styled.section`
   height: 240px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
 `;
 

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -73,7 +73,7 @@ const TopicInfo = ({
       role="button"
       data-cy="topic-info"
     >
-      <Image
+      <TopicImage
         height="168px"
         width="332px"
         src={topicImage}
@@ -127,7 +127,7 @@ const TopicInfo = ({
         <AddSeeTogether
           isInAtlas={isInAtlas}
           id={Number(topicId.split(',')[idx])}
-          setTopicsFromServer={setTopicsFromServer}
+          getTopicsFromServer={setTopicsFromServer}
         >
           {isInAtlas ? (
             <SeeTogetherSVG width="40px" height="40px" />
@@ -139,7 +139,7 @@ const TopicInfo = ({
         <AddFavorite
           isBookmarked={isBookmarked}
           id={Number(topicId.split(',')[idx])}
-          setTopicsFromServer={setTopicsFromServer}
+          getTopicsFromServer={setTopicsFromServer}
         >
           {isBookmarked ? <FavoriteSVG /> : <FavoriteNotFilledSVG />}
         </AddFavorite>
@@ -156,6 +156,10 @@ const ButtonsWrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+`;
+
+const TopicImage = styled(Image)`
+  border-radius: ${({ theme }) => theme.radius.medium};
 `;
 
 export default TopicInfo;

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -75,7 +75,7 @@ const TopicInfo = ({
     >
       <TopicImage
         height="168px"
-        width="332px"
+        width="100%"
         src={topicImage}
         alt="토픽 이미지"
         $objectFit="cover"

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -7,4 +7,4 @@ export const LAYOUT_PADDING = '40px';
 export const DEFAULT_TOPIC_IMAGE =
   'https://velog.velcdn.com/images/semnil5202/post/37f3bcb9-0b07-4100-85f6-f1d5ad037c14/image.svg';
 
-export const DEFAULT_PROD_URL = 'https://mapbefine.com/api';
+export const DEFAULT_PROD_URL = 'https://mapbefine.kro.kr/api';

--- a/frontend/src/constants/responsive.ts
+++ b/frontend/src/constants/responsive.ts
@@ -1,6 +1,6 @@
 import { css } from 'styled-components';
 
-export const fullScreenResponsive = () => {
+export const setFullScreenResponsive = () => {
   return css`
     @media (max-width: 1076px) {
       width: 684px;

--- a/frontend/src/constants/responsive.ts
+++ b/frontend/src/constants/responsive.ts
@@ -1,0 +1,17 @@
+import { css } from 'styled-components';
+
+export const fullScreenResponsive = () => {
+  return css`
+    @media (max-width: 1076px) {
+      width: 684px;
+    }
+
+    @media (max-width: 724px) {
+      width: 332px;
+    }
+
+    @media (max-width: 372px) {
+      width: 332px;
+    }
+  `;
+};

--- a/frontend/src/constants/responsive.ts
+++ b/frontend/src/constants/responsive.ts
@@ -9,9 +9,5 @@ export const setFullScreenResponsive = () => {
     @media (max-width: 724px) {
       width: 332px;
     }
-
-    @media (max-width: 372px) {
-      width: 332px;
-    }
   `;
 };

--- a/frontend/src/pages/Bookmark.tsx
+++ b/frontend/src/pages/Bookmark.tsx
@@ -10,6 +10,7 @@ import { Suspense, lazy } from 'react';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
 import useNavigator from '../hooks/useNavigator';
 import FavoriteNotFilledSVG from '../assets/favoriteBtn_notFilled.svg';
+import { setFullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -53,7 +54,7 @@ const Bookmark = () => {
         <TopicCardList
           url="/members/my/bookmarks"
           errorMessage="로그인 후 이용해주세요."
-          commentWhenEmpty="버튼을 눌러 지도를 즐겨찾기에 추가해보세요."
+          commentWhenEmpty="버튼으로 지도를 즐겨찾기에 담아보세요."
           pageCommentWhenEmpty="메인페이지로 가기"
           routePage={goToHome}
         >
@@ -67,6 +68,8 @@ const Bookmark = () => {
 const Wrapper = styled.article`
   width: 1036px;
   margin: 0 auto;
+
+  ${setFullScreenResponsive()}
 `;
 
 export default Bookmark;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,13 +1,14 @@
 import Space from '../components/common/Space';
 import Box from '../components/common/Box';
 import useNavigator from '../hooks/useNavigator';
-import { styled } from 'styled-components';
+import { css, styled } from 'styled-components';
 import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
 import { FULLSCREEN } from '../constants';
 import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
 import { Suspense, lazy, useContext, useEffect } from 'react';
 import { MarkerContext } from '../context/MarkerContext';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
+import { fullScreenResponsive } from '../constants/responsive';
 
 const TopicListContainer = lazy(
   () => import('../components/TopicCardContainer'),
@@ -82,13 +83,7 @@ const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
 
-  @media (max-width: 1036px) {
-    width: calc(100vw - 40px);
-  }
-
-  @media (max-width: 372px) {
-    width: 332px;
-  }
+  ${fullScreenResponsive()}
 `;
 
 export default Home;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -40,49 +40,55 @@ const Home = () => {
   }, []);
 
   return (
-    <>
-      <Wrapper position="relative">
-        <Space size={5} />
-        <Suspense fallback={<TopicCardContainerSkeleton />}>
-          <TopicListContainer
-            url="/topics/bests"
-            containerTitle="인기 급상승할 지도?"
-            containerDescription="즐겨찾기가 많이 된 지도를 확인해보세요."
-            routeWhenSeeAll={goToPopularTopics}
-          />
-        </Suspense>
+    <Wrapper position="relative" as="article">
+      <Space size={5} />
+      <Suspense fallback={<TopicCardContainerSkeleton />}>
+        <TopicListContainer
+          url="/topics/bests"
+          containerTitle="인기 급상승할 지도?"
+          containerDescription="즐겨찾기가 많이 된 지도를 확인해보세요."
+          routeWhenSeeAll={goToPopularTopics}
+        />
+      </Suspense>
 
-        <Space size={9} />
+      <Space size={9} />
 
-        <Suspense fallback={<TopicCardContainerSkeleton />}>
-          <TopicListContainer
-            url="/topics/newest"
-            containerTitle="새로울 지도?"
-            containerDescription="방금 새로운 핀이 추가된 지도를 확인해보세요."
-            routeWhenSeeAll={goToLatestTopics}
-          />
-        </Suspense>
+      <Suspense fallback={<TopicCardContainerSkeleton />}>
+        <TopicListContainer
+          url="/topics/newest"
+          containerTitle="새로울 지도?"
+          containerDescription="방금 핀이 추가된 지도를 확인해보세요."
+          routeWhenSeeAll={goToLatestTopics}
+        />
+      </Suspense>
 
-        <Space size={9} />
+      <Space size={9} />
 
-        <Suspense fallback={<TopicCardContainerSkeleton />}>
-          <TopicListContainer
-            url="/topics"
-            containerTitle="모두일 지도?"
-            containerDescription="괜찮을지도의 모든 지도를 확인해보세요."
-            routeWhenSeeAll={goToNearByMeTopics}
-          />
-        </Suspense>
+      <Suspense fallback={<TopicCardContainerSkeleton />}>
+        <TopicListContainer
+          url="/topics"
+          containerTitle="모두일 지도?"
+          containerDescription="괜찮을지도의 모든 지도를 확인해보세요."
+          routeWhenSeeAll={goToNearByMeTopics}
+        />
+      </Suspense>
 
-        <Space size={5} />
-      </Wrapper>
-    </>
+      <Space size={5} />
+    </Wrapper>
   );
 };
 
 const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
+
+  @media (max-width: 1036px) {
+    width: calc(100vw - 40px);
+  }
+
+  @media (max-width: 372px) {
+    width: 332px;
+  }
 `;
 
 export default Home;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -8,7 +8,7 @@ import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
 import { Suspense, lazy, useContext, useEffect } from 'react';
 import { MarkerContext } from '../context/MarkerContext';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
-import { fullScreenResponsive } from '../constants/responsive';
+import { setFullScreenResponsive } from '../constants/responsive';
 
 const TopicListContainer = lazy(
   () => import('../components/TopicCardContainer'),
@@ -83,7 +83,7 @@ const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
 
-  ${fullScreenResponsive()}
+  ${setFullScreenResponsive()}
 `;
 
 export default Home;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -41,7 +41,7 @@ const Home = () => {
   }, []);
 
   return (
-    <Wrapper position="relative" as="article">
+    <Wrapper>
       <Space size={5} />
       <Suspense fallback={<TopicCardContainerSkeleton />}>
         <TopicListContainer
@@ -79,9 +79,10 @@ const Home = () => {
   );
 };
 
-const Wrapper = styled(Box)`
+const Wrapper = styled.article`
   width: 1036px;
   margin: 0 auto;
+  position: relative;
 
   ${setFullScreenResponsive()}
 `;

--- a/frontend/src/pages/KakaoRedirect.tsx
+++ b/frontend/src/pages/KakaoRedirect.tsx
@@ -23,7 +23,7 @@ export const handleOAuthKakao = async (code: string) => {
   }
 };
 
-const KakaoRedirectPage = () => {
+const KakaoRedirect = () => {
   const { routePage } = useNavigator();
 
   const routerLocation = useLocation();
@@ -48,7 +48,7 @@ const KakaoRedirectPage = () => {
   );
 };
 
-export default KakaoRedirectPage;
+export default KakaoRedirect;
 
 const KakaoRedirectPageWrapper = styled.div`
   display: flex;

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -184,7 +184,7 @@ const NewPin = () => {
     <>
       <form onSubmit={onSubmit}>
         <Space size={4} />
-        <Flex
+        <Wrapper
           width={`calc(${width} - ${LAYOUT_PADDING})`}
           $flexDirection="column"
         >
@@ -194,32 +194,30 @@ const NewPin = () => {
 
           <Space size={5} />
 
-          <section>
-            <Flex>
-              <Text color="black" $fontSize="default" $fontWeight="normal">
-                지도 선택
-              </Text>
-              <Space size={0} />
-              <Text color="primary" $fontSize="extraSmall" $fontWeight="normal">
-                *
-              </Text>
-            </Flex>
+          <Flex>
+            <Text color="black" $fontSize="default" $fontWeight="normal">
+              지도 선택
+            </Text>
             <Space size={0} />
-            <Button
-              type="button"
-              variant="primary"
-              onClick={() => {
-                if (topic && topic.name) return;
-                openModal('newPin');
-              }}
-            >
-              {topic?.name
-                ? topic?.name
-                : selectedTopic?.topicName
-                ? selectedTopic?.topicName
-                : '지도를 선택해주세요.'}
-            </Button>
-          </section>
+            <Text color="primary" $fontSize="extraSmall" $fontWeight="normal">
+              *
+            </Text>
+          </Flex>
+          <Space size={0} />
+          <Button
+            type="button"
+            variant="primary"
+            onClick={() => {
+              if (topic && topic.name) return;
+              openModal('newPin');
+            }}
+          >
+            {topic?.name
+              ? topic?.name
+              : selectedTopic?.topicName
+              ? selectedTopic?.topicName
+              : '지도를 선택해주세요.'}
+          </Button>
 
           <Space size={5} />
 
@@ -239,27 +237,25 @@ const NewPin = () => {
 
           <Space size={1} />
 
-          <section>
-            <Flex>
-              <Text color="black" $fontSize="default" $fontWeight="normal">
-                장소 위치
-              </Text>
-              <Space size={0} />
-              <Text color="primary" $fontSize="extraSmall" $fontWeight="normal">
-                *
-              </Text>
-            </Flex>
+          <Flex>
+            <Text color="black" $fontSize="default" $fontWeight="normal">
+              장소 위치
+            </Text>
             <Space size={0} />
-            <Input
-              name="address"
-              readOnly
-              value={clickedCoordinate.address}
-              onClick={onClickAddressInput}
-              onKeyDown={onClickAddressInput}
-              tabIndex={2}
-              placeholder="지도를 클릭하거나 장소의 위치를 입력해주세요."
-            />
-          </section>
+            <Text color="primary" $fontSize="extraSmall" $fontWeight="normal">
+              *
+            </Text>
+          </Flex>
+          <Space size={0} />
+          <Input
+            name="address"
+            readOnly
+            value={clickedCoordinate.address}
+            onClick={onClickAddressInput}
+            onKeyDown={onClickAddressInput}
+            tabIndex={2}
+            placeholder="지도를 클릭하거나 장소의 위치를 입력해주세요."
+          />
 
           <Space size={5} />
 
@@ -292,7 +288,7 @@ const NewPin = () => {
               추가하기
             </Button>
           </Flex>
-        </Flex>
+        </Wrapper>
       </form>
 
       <Modal
@@ -317,6 +313,19 @@ const NewPin = () => {
     </>
   );
 };
+
+const Wrapper = styled(Flex)`
+  margin: 0 auto;
+
+  @media (max-width: 1076px) {
+    width: calc(50vw - 40px);
+  }
+
+  @media (max-width: 744px) {
+    width: ${({ width }) => width};
+    margin: 0 auto;
+  }
+`;
 
 const ModalContentsWrapper = styled.div`
   width: 100%;

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -294,7 +294,7 @@ const NewPin = () => {
       <Modal
         modalKey="newPin"
         position="center"
-        width="768px"
+        width="744px"
         height="512px"
         $dimmedColor="rgba(0,0,0,0.25)"
       >

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -110,7 +110,7 @@ const PinDetail = ({
     );
 
   return (
-    <Wrapper $layoutWidth={width} $selectedPinId={pinId}>
+    <Wrapper $layoutWidth={width} $selectedPinId={pinId} data-cy="pin-detail">
       <Flex $justifyContent="space-between" $alignItems="baseline" width="100%">
         <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
           {pin.name}

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -17,6 +17,7 @@ import { ModalContext } from '../context/ModalContext';
 import AddToMyTopicList from '../components/ModalMyTopicList/addToMyTopicList';
 
 interface PinDetailProps {
+  width: '372px' | '100vw';
   topicId: string;
   pinId: number;
   isEditPinDetail: boolean;
@@ -26,6 +27,7 @@ interface PinDetailProps {
 const userToken = localStorage.getItem('userToken');
 
 const PinDetail = ({
+  width,
   topicId,
   pinId,
   isEditPinDetail,
@@ -110,7 +112,7 @@ const PinDetail = ({
     );
 
   return (
-    <>
+    <Wrapper $mediaWidth={width}>
       <Flex $justifyContent="space-between" $alignItems="baseline" width="100%">
         <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
           {pin.name}
@@ -184,6 +186,8 @@ const PinDetail = ({
         </Text>
       </Flex>
 
+      <Space size={7} />
+
       <ButtonsWrapper>
         <SaveToMyMapButton variant="primary" onClick={openModalWithToken}>
           내 지도에 저장하기
@@ -213,9 +217,30 @@ const PinDetail = ({
           <AddToMyTopicList pin={pin} />
         </ModalContentsWrapper>
       </Modal>
-    </>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
+  display: flex;
+  flex-direction: column;
+  width: ${({ $mediaWidth }) => $mediaWidth};
+  height: 100vh;
+  overflow: auto;
+  position: absolute;
+  top: 0;
+  left: ${({ $mediaWidth }) => $mediaWidth};
+  padding: ${({ theme }) => theme.spacing[4]};
+  border-left: 1px solid ${({ theme }) => theme.color.gray};
+  background-color: ${({ theme }) => theme.color.white};
+  z-index: 2;
+
+  @media (max-width: 1076px) {
+    margin-top: 50vh;
+    height: ${({ $mediaWidth }) => $mediaWidth === '372px' && '50vh'};
+    left: ${({ $mediaWidth }) => $mediaWidth === '372px' && 0};
+  }
+`;
 
 const PinDetailImgContainer = styled(Flex)`
   box-shadow: 8px 8px 8px 0px rgba(69, 69, 69, 0.15);
@@ -251,8 +276,6 @@ const ButtonsWrapper = styled.div`
   align-items: center;
   width: 332px;
   height: 48px;
-  position: fixed;
-  bottom: 24px;
 `;
 
 export default PinDetail;

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -203,7 +203,7 @@ const PinDetail = ({
       <Modal
         modalKey="addToMyTopicList"
         position="center"
-        width="768px"
+        width="744px"
         height="512px"
         $dimmedColor="rgba(0,0,0,0.25)"
       >

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -59,23 +59,19 @@ const PinDetail = ({
     showToast('error', '로그인 후 사용해주세요.');
   };
 
-  useEffect(() => {
-    const getPinData = async () => {
-      const pinData = await getApi<PinProps>(`/pins/${pinId}`);
-      setPin(pinData);
-      setFormValues({
-        name: pinData.name,
-        images: pinData.images,
-        description: pinData.description,
-      });
-    };
+  const getPinData = async () => {
+    const pinData = await getApi<PinProps>(`/pins/${pinId}`);
+    setPin(pinData);
+    setFormValues({
+      name: pinData.name,
+      images: pinData.images,
+      description: pinData.description,
+    });
+  };
 
+  useEffect(() => {
     getPinData();
   }, [pinId, searchParams]);
-
-  const updateQueryString = (key: string, value: string) => {
-    setSearchParams({ ...Object.fromEntries(searchParams), [key]: value });
-  };
 
   const onClickEditPin = () => {
     setIsEditPinDetail(true);
@@ -84,7 +80,6 @@ const PinDetail = ({
       images: '',
       description: '',
     });
-    updateQueryString('edit', 'true');
   };
 
   const copyContent = async () => {
@@ -100,15 +95,18 @@ const PinDetail = ({
 
   if (isEditPinDetail)
     return (
-      <UpdatedPinDetail
-        searchParams={searchParams}
-        setSearchParams={setSearchParams}
-        setIsEditing={setIsEditPinDetail}
-        pinId={pinId}
-        formValues={formValues}
-        errorMessages={errorMessages}
-        onChangeInput={onChangeInput}
-      />
+      <Wrapper $layoutWidth={width} $selectedPinId={pinId}>
+        <UpdatedPinDetail
+          searchParams={searchParams}
+          setSearchParams={setSearchParams}
+          setIsEditing={setIsEditPinDetail}
+          updatePinDetailAfterEditing={getPinData}
+          pinId={pinId}
+          formValues={formValues}
+          errorMessages={errorMessages}
+          onChangeInput={onChangeInput}
+        />
+      </Wrapper>
     );
 
   return (
@@ -192,7 +190,7 @@ const PinDetail = ({
         <SaveToMyMapButton variant="primary" onClick={openModalWithToken}>
           내 지도에 저장하기
         </SaveToMyMapButton>
-        <Space size={4} />
+        <Space size={3} />
         <ShareButton variant="secondary" onClick={copyContent}>
           공유하기
         </ShareButton>

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -112,7 +112,7 @@ const PinDetail = ({
     );
 
   return (
-    <Wrapper $mediaWidth={width} $selectedPinId={pinId}>
+    <Wrapper $layoutWidth={width} $selectedPinId={pinId}>
       <Flex $justifyContent="space-between" $alignItems="baseline" width="100%">
         <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
           {pin.name}
@@ -223,18 +223,18 @@ const PinDetail = ({
   );
 };
 
-const Wrapper = styled.div<{
-  $mediaWidth: '372px' | '100vw';
+const Wrapper = styled.section<{
+  $layoutWidth: '372px' | '100vw';
   $selectedPinId: number | null;
 }>`
   display: flex;
   flex-direction: column;
-  width: ${({ $mediaWidth }) => $mediaWidth};
+  width: ${({ $layoutWidth }) => $layoutWidth};
   height: 100vh;
   overflow: auto;
   position: absolute;
   top: 0;
-  left: ${({ $mediaWidth }) => $mediaWidth};
+  left: ${({ $layoutWidth }) => $layoutWidth};
   padding: ${({ theme }) => theme.spacing[4]};
   border-left: 1px solid ${({ theme }) => theme.color.gray};
   background-color: ${({ theme }) => theme.color.white};
@@ -243,7 +243,7 @@ const Wrapper = styled.div<{
   @media (max-width: 1076px) {
     width: 50vw;
     margin-top: 50vh;
-    height: ${({ $mediaWidth }) => $mediaWidth === '372px' && '50vh'};
+    height: ${({ $layoutWidth }) => $layoutWidth === '372px' && '50vh'};
     left: ${({ $selectedPinId }) => $selectedPinId && '50vw'};
   }
 
@@ -254,7 +254,7 @@ const Wrapper = styled.div<{
   }
 
   @media (max-width: 372px) {
-    width: ${({ $mediaWidth }) => $mediaWidth};
+    width: ${({ $layoutWidth }) => $layoutWidth};
   }
 `;
 

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -198,7 +198,7 @@ const PinDetail = ({
         </ShareButton>
       </ButtonsWrapper>
 
-      <Space size={7} />
+      <Space size={8} />
 
       <Modal
         modalKey="addToMyTopicList"
@@ -249,12 +249,12 @@ const Wrapper = styled.div<{
 
   @media (max-width: 744px) {
     border-left: 0;
-    left: calc((100vw - 372px) / 2);
-    width: ${({ $mediaWidth }) => $mediaWidth};
+    left: 0;
+    width: 100vw;
   }
 
   @media (max-width: 372px) {
-    left: 0;
+    width: ${({ $mediaWidth }) => $mediaWidth};
   }
 `;
 
@@ -292,6 +292,7 @@ const ButtonsWrapper = styled.div`
   align-items: center;
   width: 332px;
   height: 48px;
+  margin: 0 auto;
 `;
 
 export default PinDetail;

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -112,7 +112,7 @@ const PinDetail = ({
     );
 
   return (
-    <Wrapper $mediaWidth={width}>
+    <Wrapper $mediaWidth={width} selectedPinId={pinId}>
       <Flex $justifyContent="space-between" $alignItems="baseline" width="100%">
         <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
           {pin.name}
@@ -198,6 +198,8 @@ const PinDetail = ({
         </ShareButton>
       </ButtonsWrapper>
 
+      <Space size={7} />
+
       <Modal
         modalKey="addToMyTopicList"
         position="center"
@@ -221,7 +223,10 @@ const PinDetail = ({
   );
 };
 
-const Wrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
+const Wrapper = styled.div<{
+  $mediaWidth: '372px' | '100vw';
+  selectedPinId: number | null;
+}>`
   display: flex;
   flex-direction: column;
   width: ${({ $mediaWidth }) => $mediaWidth};
@@ -233,12 +238,23 @@ const Wrapper = styled.section<{ $mediaWidth: '372px' | '100vw' }>`
   padding: ${({ theme }) => theme.spacing[4]};
   border-left: 1px solid ${({ theme }) => theme.color.gray};
   background-color: ${({ theme }) => theme.color.white};
-  z-index: 2;
+  z-index: 1;
 
   @media (max-width: 1076px) {
+    width: 50vw;
     margin-top: 50vh;
     height: ${({ $mediaWidth }) => $mediaWidth === '372px' && '50vh'};
-    left: ${({ $mediaWidth }) => $mediaWidth === '372px' && 0};
+    left: ${({ selectedPinId }) => selectedPinId && '50vw'};
+  }
+
+  @media (max-width: 744px) {
+    border-left: 0;
+    left: calc((100vw - 372px) / 2);
+    width: ${({ $mediaWidth }) => $mediaWidth};
+  }
+
+  @media (max-width: 372px) {
+    left: 0;
   }
 `;
 

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -112,7 +112,7 @@ const PinDetail = ({
     );
 
   return (
-    <Wrapper $mediaWidth={width} selectedPinId={pinId}>
+    <Wrapper $mediaWidth={width} $selectedPinId={pinId}>
       <Flex $justifyContent="space-between" $alignItems="baseline" width="100%">
         <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
           {pin.name}
@@ -225,7 +225,7 @@ const PinDetail = ({
 
 const Wrapper = styled.div<{
   $mediaWidth: '372px' | '100vw';
-  selectedPinId: number | null;
+  $selectedPinId: number | null;
 }>`
   display: flex;
   flex-direction: column;
@@ -244,7 +244,7 @@ const Wrapper = styled.div<{
     width: 50vw;
     margin-top: 50vh;
     height: ${({ $mediaWidth }) => $mediaWidth === '372px' && '50vh'};
-    left: ${({ selectedPinId }) => selectedPinId && '50vw'};
+    left: ${({ $selectedPinId }) => $selectedPinId && '50vw'};
   }
 
   @media (max-width: 744px) {

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -10,6 +10,7 @@ import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleto
 import { Suspense, lazy } from 'react';
 import Text from '../components/common/Text';
 import useNavigator from '../hooks/useNavigator';
+import { setFullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -70,6 +71,8 @@ const Profile = () => {
 const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
+
+  ${setFullScreenResponsive()}
 `;
 
 const MyInfoWrapper = styled(Flex)`

--- a/frontend/src/pages/RootPage.tsx
+++ b/frontend/src/pages/RootPage.tsx
@@ -1,14 +1,17 @@
 import { Outlet } from 'react-router-dom';
 import Layout from '../components/Layout';
 import LayoutWidthProvider from '../context/LayoutWidthContext';
+import NavbarHighlightsProvider from '../context/NavbarHighlightsContext';
 
 const RootPage = () => {
   return (
     <>
       <LayoutWidthProvider>
-        <Layout>
-          <Outlet />
-        </Layout>
+        <NavbarHighlightsProvider>
+          <Layout>
+            <Outlet />
+          </Layout>
+        </NavbarHighlightsProvider>
       </LayoutWidthProvider>
     </>
   );

--- a/frontend/src/pages/SeeAllLatestTopics.tsx
+++ b/frontend/src/pages/SeeAllLatestTopics.tsx
@@ -8,6 +8,7 @@ import Box from '../components/common/Box';
 import { Suspense, lazy } from 'react';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
 import useNavigator from '../hooks/useNavigator';
+import { fullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -45,6 +46,8 @@ const SeeAllLatestTopics = () => {
 const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
+
+  ${fullScreenResponsive()}
 `;
 
 export default SeeAllLatestTopics;

--- a/frontend/src/pages/SeeAllLatestTopics.tsx
+++ b/frontend/src/pages/SeeAllLatestTopics.tsx
@@ -8,7 +8,7 @@ import Box from '../components/common/Box';
 import { Suspense, lazy } from 'react';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
 import useNavigator from '../hooks/useNavigator';
-import { fullScreenResponsive } from '../constants/responsive';
+import { setFullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -47,7 +47,7 @@ const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
 
-  ${fullScreenResponsive()}
+  ${setFullScreenResponsive()}
 `;
 
 export default SeeAllLatestTopics;

--- a/frontend/src/pages/SeeAllNearTopics.tsx
+++ b/frontend/src/pages/SeeAllNearTopics.tsx
@@ -8,6 +8,7 @@ import Text from '../components/common/Text';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
 import { Suspense, lazy } from 'react';
 import useNavigator from '../hooks/useNavigator';
+import { fullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -45,6 +46,8 @@ const SeeAllNearTopics = () => {
 const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
+
+  ${fullScreenResponsive()}
 `;
 
 export default SeeAllNearTopics;

--- a/frontend/src/pages/SeeAllNearTopics.tsx
+++ b/frontend/src/pages/SeeAllNearTopics.tsx
@@ -8,7 +8,7 @@ import Text from '../components/common/Text';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
 import { Suspense, lazy } from 'react';
 import useNavigator from '../hooks/useNavigator';
-import { fullScreenResponsive } from '../constants/responsive';
+import { setFullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -47,7 +47,7 @@ const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
 
-  ${fullScreenResponsive()}
+  ${setFullScreenResponsive()}
 `;
 
 export default SeeAllNearTopics;

--- a/frontend/src/pages/SeeAllPopularTopics.tsx
+++ b/frontend/src/pages/SeeAllPopularTopics.tsx
@@ -8,6 +8,7 @@ import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
 import { Suspense, lazy } from 'react';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
 import useNavigator from '../hooks/useNavigator';
+import { fullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -45,6 +46,8 @@ const SeeAllTopics = () => {
 const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
+
+  ${fullScreenResponsive()}
 `;
 
 export default SeeAllTopics;

--- a/frontend/src/pages/SeeAllPopularTopics.tsx
+++ b/frontend/src/pages/SeeAllPopularTopics.tsx
@@ -8,7 +8,7 @@ import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
 import { Suspense, lazy } from 'react';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
 import useNavigator from '../hooks/useNavigator';
-import { fullScreenResponsive } from '../constants/responsive';
+import { setFullScreenResponsive } from '../constants/responsive';
 
 const TopicCardList = lazy(() => import('../components/TopicCardList'));
 
@@ -47,7 +47,7 @@ const Wrapper = styled(Box)`
   width: 1036px;
   margin: 0 auto;
 
-  ${fullScreenResponsive()}
+  ${setFullScreenResponsive()}
 `;
 
 export default SeeAllTopics;

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -172,8 +172,11 @@ const Wrapper = styled.section<{
   }
 
   @media (max-width: 744px) {
+    width: 100%;
+  }
+
+  @media (max-width: 372px) {
     width: ${({ width }) => width};
-    margin: 0 auto;
   }
 `;
 

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -8,10 +8,8 @@ import {
 } from 'react';
 import { styled } from 'styled-components';
 import Space from '../components/common/Space';
-import Flex from '../components/common/Flex';
 import { TopicDetailProps } from '../types/Topic';
 import { useParams, useSearchParams } from 'react-router-dom';
-import theme from '../themes';
 import PinDetail from './PinDetail';
 import { getApi } from '../apis/getApi';
 import PullPin from '../components/PullPin';
@@ -111,10 +109,9 @@ const SelectedTopic = () => {
   if (!topicId) return <></>;
 
   return (
-    <Flex
+    <Wrapper
       width={`calc(${width} - ${LAYOUT_PADDING})`}
-      $flexDirection="column"
-      as="section"
+      selectedPinId={selectedPinId}
     >
       <Space size={3} />
       {tags.length > 0 && (
@@ -157,9 +154,28 @@ const SelectedTopic = () => {
           </PinDetailWrapper>
         </>
       )}
-    </Flex>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.section<{
+  width: 'calc(100vw - 40px)' | 'calc(372px - 40px)';
+  selectedPinId: number | null;
+}>`
+  display: flex;
+  flex-direction: column;
+  width: ${({ width }) => width};
+  margin: ${({ selectedPinId }) => selectedPinId === null && '0 auto'};
+
+  @media (max-width: 1076px) {
+    width: calc(50vw - 40px);
+  }
+
+  @media (max-width: 744px) {
+    width: ${({ width }) => width};
+    margin: 0 auto;
+  }
+`;
 
 const PinDetailWrapper = styled.div`
   &.collapsedPinDetail {

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -89,8 +89,6 @@ const SelectedTopic = () => {
   useEffect(() => {
     getAndSetDataFromServer();
 
-    console.log(location);
-
     const queryParams = new URLSearchParams(location.search);
     if (queryParams.has('pinDetail')) {
       setSelectedPinId(Number(queryParams.get('pinDetail')));
@@ -113,67 +111,66 @@ const SelectedTopic = () => {
   if (!topicId) return <></>;
 
   return (
-    <>
-      <Flex
-        width={`calc(${width} - ${LAYOUT_PADDING})`}
-        $flexDirection="column"
-      >
-        <Space size={3} />
-        {tags.length > 0 && (
-          <PullPin
-            tags={tags}
-            confirmButton="뽑아오기"
-            onClickConfirm={onClickConfirm}
-            onClickClose={onTagCancel}
-          />
-        )}
-        <Suspense fallback={<PinsOfTopicSkeleton />}>
-          {topicDetails.map((topicDetail, idx) => (
-            <Fragment key={topicDetail.id}>
-              <PinsOfTopic
-                topicId={topicId}
-                idx={idx}
-                topicDetail={topicDetail}
-                setSelectedPinId={setSelectedPinId}
-                setIsEditPinDetail={setIsEditPinDetail}
-                setTopicsFromServer={getAndSetDataFromServer}
-              />
-              {idx !== topicDetails.length - 1 ? <Space size={9} /> : <></>}
-            </Fragment>
-          ))}
-        </Suspense>
+    <Flex
+      width={`calc(${width} - ${LAYOUT_PADDING})`}
+      $flexDirection="column"
+      as="section"
+    >
+      <Space size={3} />
+      {tags.length > 0 && (
+        <PullPin
+          tags={tags}
+          confirmButton="뽑아오기"
+          onClickConfirm={onClickConfirm}
+          onClickClose={onTagCancel}
+        />
+      )}
+      <Suspense fallback={<PinsOfTopicSkeleton />}>
+        {topicDetails.map((topicDetail, idx) => (
+          <Fragment key={topicDetail.id}>
+            <PinsOfTopic
+              topicId={topicId}
+              idx={idx}
+              topicDetail={topicDetail}
+              setSelectedPinId={setSelectedPinId}
+              setIsEditPinDetail={setIsEditPinDetail}
+              setTopicsFromServer={getAndSetDataFromServer}
+            />
+            {idx !== topicDetails.length - 1 ? <Space size={9} /> : <></>}
+          </Fragment>
+        ))}
+      </Suspense>
 
-        {selectedPinId && (
-          <>
-            <ToggleButton $isCollapsed={!isOpen} onClick={togglePinDetail}>
-              ◀
-            </ToggleButton>
-            <PinDetailWrapper className={isOpen ? '' : 'collapsedPinDetail'}>
-              <Flex
-                $backgroundColor="white"
-                width={width}
-                height="100vh"
-                overflow="auto"
-                position="absolute"
-                left={width}
-                top="0px"
-                padding={4}
-                $flexDirection="column"
-                $borderLeft={`1px solid ${theme.color.gray}`}
-                $zIndex={1}
-              >
-                <PinDetail
-                  topicId={topicId}
-                  pinId={selectedPinId}
-                  isEditPinDetail={isEditPinDetail}
-                  setIsEditPinDetail={setIsEditPinDetail}
-                />
-              </Flex>
-            </PinDetailWrapper>
-          </>
-        )}
-      </Flex>
-    </>
+      {selectedPinId && (
+        <>
+          <ToggleButton $isCollapsed={!isOpen} onClick={togglePinDetail}>
+            ◀
+          </ToggleButton>
+          <PinDetailWrapper className={isOpen ? '' : 'collapsedPinDetail'}>
+            <Flex
+              $backgroundColor="white"
+              width={width}
+              height="100vh"
+              overflow="auto"
+              position="absolute"
+              left={width}
+              top="0px"
+              padding={4}
+              $flexDirection="column"
+              $borderLeft={`1px solid ${theme.color.gray}`}
+              $zIndex={1}
+            >
+              <PinDetail
+                topicId={topicId}
+                pinId={selectedPinId}
+                isEditPinDetail={isEditPinDetail}
+                setIsEditPinDetail={setIsEditPinDetail}
+              />
+            </Flex>
+          </PinDetailWrapper>
+        </>
+      )}
+    </Flex>
   );
 };
 

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -147,26 +147,13 @@ const SelectedTopic = () => {
             ◀
           </ToggleButton>
           <PinDetailWrapper className={isOpen ? '' : 'collapsedPinDetail'}>
-            <Flex
-              $backgroundColor="white"
+            <PinDetail
               width={width}
-              height="100vh"
-              overflow="auto"
-              position="absolute"
-              left={width}
-              top="0px"
-              padding={4}
-              $flexDirection="column"
-              $borderLeft={`1px solid ${theme.color.gray}`}
-              $zIndex={1}
-            >
-              <PinDetail
-                topicId={topicId}
-                pinId={selectedPinId}
-                isEditPinDetail={isEditPinDetail}
-                setIsEditPinDetail={setIsEditPinDetail}
-              />
-            </Flex>
+              topicId={topicId}
+              pinId={selectedPinId}
+              isEditPinDetail={isEditPinDetail}
+              setIsEditPinDetail={setIsEditPinDetail}
+            />
           </PinDetailWrapper>
         </>
       )}
@@ -180,7 +167,9 @@ const PinDetailWrapper = styled.div`
   }
 `;
 
-const ToggleButton = styled.button<{ $isCollapsed: boolean }>`
+const ToggleButton = styled.button<{
+  $isCollapsed: boolean;
+}>`
   position: absolute;
   top: 50%;
   left: 744px;
@@ -204,6 +193,10 @@ const ToggleButton = styled.button<{ $isCollapsed: boolean }>`
 
   &:hover {
     background-color: #f5f5f5;
+  }
+
+  @media (max-width: 1076px) {
+    display: none;
   }
 `;
 

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -89,9 +89,13 @@ const SelectedTopic = () => {
   useEffect(() => {
     getAndSetDataFromServer();
 
+    console.log(location);
+
     const queryParams = new URLSearchParams(location.search);
     if (queryParams.has('pinDetail')) {
       setSelectedPinId(Number(queryParams.get('pinDetail')));
+    } else {
+      setSelectedPinId(null);
     }
 
     setIsOpen(true);

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -111,7 +111,7 @@ const SelectedTopic = () => {
   return (
     <Wrapper
       width={`calc(${width} - ${LAYOUT_PADDING})`}
-      selectedPinId={selectedPinId}
+      $selectedPinId={selectedPinId}
     >
       <Space size={3} />
       {tags.length > 0 && (
@@ -160,12 +160,12 @@ const SelectedTopic = () => {
 
 const Wrapper = styled.section<{
   width: 'calc(100vw - 40px)' | 'calc(372px - 40px)';
-  selectedPinId: number | null;
+  $selectedPinId: number | null;
 }>`
   display: flex;
   flex-direction: column;
   width: ${({ width }) => width};
-  margin: ${({ selectedPinId }) => selectedPinId === null && '0 auto'};
+  margin: ${({ $selectedPinId }) => $selectedPinId === null && '0 auto'};
 
   @media (max-width: 1076px) {
     width: calc(50vw - 40px);

--- a/frontend/src/pages/UpdatedPinDetail.tsx
+++ b/frontend/src/pages/UpdatedPinDetail.tsx
@@ -8,6 +8,7 @@ import InputContainer from '../components/InputContainer';
 import { hasErrorMessage, hasNullValue } from '../validations';
 import useToast from '../hooks/useToast';
 import Button from '../components/common/Button';
+import styled from 'styled-components';
 
 interface UpdatedPinDetailProps {
   searchParams: URLSearchParams;
@@ -65,7 +66,7 @@ const UpdatedPinDetail = ({
   };
 
   return (
-    <>
+    <Wrapper>
       <Flex
         width="100%"
         height="180px"
@@ -132,8 +133,21 @@ const UpdatedPinDetail = ({
       </Flex>
 
       <Space size={8} />
-    </>
+    </Wrapper>
   );
 };
+
+const Wrapper = styled.div`
+  margin: 0 auto;
+
+  @media (max-width: 1076px) {
+    width: calc(50vw - 40px);
+  }
+
+  @media (max-width: 744px) {
+    width: 332px;
+    margin: 0 auto;
+  }
+`;
 
 export default UpdatedPinDetail;

--- a/frontend/src/pages/UpdatedPinDetail.tsx
+++ b/frontend/src/pages/UpdatedPinDetail.tsx
@@ -1,13 +1,13 @@
 import Flex from '../components/common/Flex';
 import Space from '../components/common/Space';
 import Text from '../components/common/Text';
-import Box from '../components/common/Box';
 import { putApi } from '../apis/putApi';
 import { SetURLSearchParams } from 'react-router-dom';
 import { ModifyPinFormProps } from '../types/FormValues';
 import InputContainer from '../components/InputContainer';
 import { hasErrorMessage, hasNullValue } from '../validations';
 import useToast from '../hooks/useToast';
+import Button from '../components/common/Button';
 
 interface UpdatedPinDetailProps {
   searchParams: URLSearchParams;
@@ -15,6 +15,7 @@ interface UpdatedPinDetailProps {
   formValues: ModifyPinFormProps;
   errorMessages: Record<keyof ModifyPinFormProps, string>;
   setSearchParams: SetURLSearchParams;
+  updatePinDetailAfterEditing: () => void;
   setIsEditing: React.Dispatch<React.SetStateAction<boolean>>;
   onChangeInput: (
     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
@@ -30,6 +31,7 @@ const UpdatedPinDetail = ({
   errorMessages,
   setSearchParams,
   setIsEditing,
+  updatePinDetailAfterEditing,
   onChangeInput,
 }: UpdatedPinDetailProps) => {
   const { showToast } = useToast();
@@ -49,6 +51,7 @@ const UpdatedPinDetail = ({
       await putApi(`/pins/${pinId}`, formValues);
       setIsEditing(false);
       removeQueryString('edit');
+      updatePinDetailAfterEditing();
 
       showToast('info', '핀 수정을 완료하였습니다.');
     } catch (error) {
@@ -62,7 +65,7 @@ const UpdatedPinDetail = ({
   };
 
   return (
-    <Flex $flexDirection="column">
+    <>
       <Flex
         width="100%"
         height="180px"
@@ -89,10 +92,10 @@ const UpdatedPinDetail = ({
       <InputContainer
         tagType="input"
         containerTitle="장소 이름"
-        isRequired={false}
+        isRequired={true}
         name="name"
         value={formValues.name}
-        placeholder="지도를 클릭하거나 장소의 이름을 입력해주세요."
+        placeholder="50글자 이내로 장소의 이름을 입력해주세요."
         onChangeInput={onChangeInput}
         tabIndex={1}
         errorMessage={errorMessages.name}
@@ -100,12 +103,12 @@ const UpdatedPinDetail = ({
         maxLength={50}
       />
 
-      <Space size={5} />
+      <Space size={1} />
 
       <InputContainer
         tagType="textarea"
         containerTitle="장소 설명"
-        isRequired={false}
+        isRequired={true}
         name="description"
         value={formValues.description}
         placeholder="1000자 이내로 장소에 대한 의견을 남겨주세요."
@@ -116,32 +119,20 @@ const UpdatedPinDetail = ({
         maxLength={1000}
       />
 
-      <Space size={3} />
+      <Space size={6} />
 
       <Flex $justifyContent="end">
-        <Box cursor="pointer">
-          <Text
-            color="black"
-            $fontSize="default"
-            $fontWeight="normal"
-            onClick={onClickCancelPinUpdate}
-          >
-            취소
-          </Text>
-        </Box>
-        <Space size={2} />
-        <Box cursor="pointer">
-          <Text
-            color="primary"
-            $fontSize="default"
-            $fontWeight="normal"
-            onClick={onClickUpdatePin}
-          >
-            저장
-          </Text>
-        </Box>
+        <Button variant="secondary" onClick={onClickCancelPinUpdate}>
+          취소하기
+        </Button>
+        <Space size={3} />
+        <Button variant="primary" onClick={onClickUpdatePin}>
+          수정하기
+        </Button>
       </Flex>
-    </Flex>
+
+      <Space size={8} />
+    </>
   );
 };
 

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -7,7 +7,7 @@ import SelectedTopic from './pages/SelectedTopic';
 import SeeAllPopularTopics from './pages/SeeAllPopularTopics';
 import SeeAllNearTopics from './pages/SeeAllNearTopics';
 import SeeAllLatestTopics from './pages/SeeAllLatestTopics';
-import KakaoRedirectPage from './pages/KakaoRedirectPage';
+import KakaoRedirect from './pages/KakaoRedirect';
 import { ReactNode } from 'react';
 import AuthLayout from './components/Layout/AuthLayout';
 import NotFound from './pages/NotFound';
@@ -90,7 +90,7 @@ const routes: routeElement[] = [
       },
       {
         path: '/oauth/redirected/kakao',
-        element: <KakaoRedirectPage />,
+        element: <KakaoRedirect />,
         withAuth: false,
       },
     ],


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->
![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/146c5763-0f8f-4f0b-af37-6a12a44d69fa)

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
모든 페이지를 대상으로 태블릿, 모바일 반응형 UI를 적용하였습니다.
개발서버 CD, test 자동화 yml을 수정하였습니다. (test 자동화 실행 확인하였습니다만, 테스트결과 로컬과 다른 부분이 있습니다.)

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] 모든 페이지에 대해 태블릿 반응형 대응
- [x] 모든 페이지에 대해 모바일 반응형 대응
- [x] PR merge CD 브랜치설정, 테스트 자동화 설정 yml 수정 

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
* new-topic 페이지는 ui 전체가 수정될 예정이므로 반응형 대응을 하지 않았습니다만, 사용할 수 있는 수준입니다.
* 모아보기 페이지 역시 페이지 자체가 삭제될 예정이므로 반응형 대응을 하지 않았습니다만, 사용할 수 있는 수준입니다.

### 여러분의 의견이 궁금합니다
#### 배경
모바일 또는 태블릿은 가상키보드를 씁니다. 현재 new-pin 페이지는 다른 페이지와는 다르게 지도가 하단에 위치하고 입력 폼이 상단에 위치하도록 두었습니다. 사용자가 입력을 보다 편리하게 할 수 있을 것이라고 생각하여 그리 진행하였습니다. 하지만 updatePinDetail 페이지는 입력폼이 하단에 위치합니다. 이렇게되면 가상키보드로 입력폼이 완전히 가려져서 사용자가 입력한 텍스트를 볼 수 없지 않나.. 했는데 그렇지는 않습니다. (위로 스크롤하면 보입니다.) 그래서 드리고자 하는 질문은 무엇이냐!

#### 질문
1. 사용자의 입력을 받는 페이지는 상단에 배치, 지도는 하단에 배치한다.
  * 장점 : 사용자가 페이지 진입해서 스크롤을 하지 않아도 입력한 내용물이 바로 보인다.
  * 단점 : 페이지 일관성을 헤친다 (지도가 들쑥날쑥)
2. 사용자의 입력을 받는 페이지도 하단에 배치, 지도를 상단에 배치한다.
  * 장점 : (~~내가 편하다.~~) 페이지 일관성을 지킬 수 있다. (지도는 항상 상단배치 고정)
  * 단점 : 사용자가 입력한 내용을 보려면 위로 스크롤을 한 번 해줘야한다. (페이지 진입시 브라우저 자체를 스크롤 해줘서 사용자가 입력하는 폼에 자동으로 포커스 맞추도록 하면 해결될지도.. 🤔)

**1번과 2번중 어떤 방식이 좋을까요??**

사실 updatePinDetail 페이지는 상단에 배치하는 것이 가능할지 모르겠습니다.. 모바일 사이즈에선 가능한데, 태블릿 사이즈에서는 selectedTopic 페이지랑 같이 있는 상태라 애매하네요.

각 페이지 스크린샷은 아래 첨부해두었습니다. 확인해보시고 의견주세용~ (쓰고 나서 다시 읽어봤는데 글이 매끄럽지 않네요. 배고파서 당 떨어져서 그러니까 이해부탁요~~)

## 스크린샷
![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/667fcfb9-f648-4543-91e8-7f5297e8d1b6)

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
closes #382
## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
