### PR TITLE
[BE] Refactor/#390 지도 및 핀 상세 조회 API에 수정 권한 여부 필드 추가

### DIFF
--- a/backend/src/docs/asciidoc/topic.adoc
+++ b/backend/src/docs/asciidoc/topic.adoc
@@ -1,23 +1,28 @@
 == 토픽
 
-=== 토픽 목록 조회
+=== 토픽 전체 목록 조회
 
 operation::topic-controller-test/find-all[snippets='http-request,http-response']
 
-=== 토픽 인기 목록 조회
+=== 최신 토픽 목록 조회
 
-operation::location-controller-test/find-nearby-topics-sorted-by-pin-count[snippets='http-request,http-response']
+operation::topic-controller-test/find-all-by-order-by-updated-at-desc[snippets='http-request,http-response']
+
+=== 인기 급상승 토픽 목록 조회 (즐겨찾기 기준)
+
+operation::topic-controller-test/find-all-best-topics[snippets='http-request,http-response']
 
 === 멤버별 토픽 목록 조회
 
 operation::topic-controller-test/find-all-topics-by-member-id[snippets='http-request,http-response']
 
+=== 주변 인기 토픽 목록 조회 (핀 개수 기준)
+
+operation::location-controller-test/find-nearby-topics-sorted-by-pin-count[snippets='http-request,http-response']
+
 === 토픽 상세 조회
 
 operation::topic-controller-test/find-by-id[snippets='http-request,http-response']
-
-=== 최신 토픽 목록 조회
-operation::topic-controller-test/find-all-by-order-by-updated-at-desc[snippets='http-request,http-response']
 
 === 토픽 생성
 
@@ -27,7 +32,8 @@ operation::topic-controller-test/create[snippets='http-request,http-response']
 
 operation::topic-controller-test/merge-and-create[snippets='http-request,http-response']
 
-== 토픽에 핀 추가
+=== 토픽에 핀 추가
+
 operation::topic-controller-test/copy-pin[snippets='http-request,http-response']
 
 === 토픽 수정
@@ -38,6 +44,3 @@ operation::topic-controller-test/update[snippets='http-request,http-response']
 
 operation::topic-controller-test/delete[snippets='http-request,http-response']
 
-=== 인기 급상승 토픽 조회
-
-operation::topic-controller-test/find-all-best-topics[snippets='http-request,http-response']

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinQueryService.java
@@ -40,7 +40,7 @@ public class PinQueryService {
                 .orElseThrow(() -> new PinNotFoundException(PIN_NOT_FOUND, pinId));
         validateReadAuth(member, pin.getTopic());
 
-        return PinDetailResponse.from(pin);
+        return PinDetailResponse.of(pin, member.canPinCreateOrUpdate(pin.getTopic()));
     }
 
     private void validateReadAuth(AuthMember member, Topic topic) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/dto/response/PinDetailResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/dto/response/PinDetailResponse.java
@@ -13,11 +13,12 @@ public record PinDetailResponse(
         String creator,
         double latitude,
         double longitude,
+        Boolean hasUpdatePermission,
         LocalDateTime updatedAt,
         List<PinImageResponse> images
 ) {
 
-    public static PinDetailResponse from(Pin pin) {
+    public static PinDetailResponse of(Pin pin, Boolean hasUpdatePermission) {
         PinInfo pinInfo = pin.getPinInfo();
 
         return new PinDetailResponse(
@@ -28,6 +29,7 @@ public record PinDetailResponse(
                 pin.getCreator().getMemberInfo().getNickName(),
                 pin.getLatitude(),
                 pin.getLongitude(),
+                hasUpdatePermission,
                 pin.getUpdatedAt(),
                 PinImageResponse.from(pin.getPinImages())
         );

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/dto/response/PinDetailResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/dto/response/PinDetailResponse.java
@@ -13,12 +13,12 @@ public record PinDetailResponse(
         String creator,
         double latitude,
         double longitude,
-        Boolean hasUpdatePermission,
+        Boolean canUpdate,
         LocalDateTime updatedAt,
         List<PinImageResponse> images
 ) {
 
-    public static PinDetailResponse of(Pin pin, Boolean hasUpdatePermission) {
+    public static PinDetailResponse of(Pin pin, Boolean canUpdate) {
         PinInfo pinInfo = pin.getPinInfo();
 
         return new PinDetailResponse(
@@ -29,7 +29,7 @@ public record PinDetailResponse(
                 pin.getCreator().getMemberInfo().getNickName(),
                 pin.getLatitude(),
                 pin.getLongitude(),
-                hasUpdatePermission,
+                canUpdate,
                 pin.getUpdatedAt(),
                 PinImageResponse.from(pin.getPinImages())
         );

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
@@ -41,6 +41,12 @@ public class TopicQueryService {
         this.memberRepository = memberRepository;
     }
 
+    private static List<TopicDetailResponse> getGuestTopicDetailResponses(List<Topic> topics) {
+        return topics.stream()
+                .map(topic -> TopicDetailResponse.from(topic, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE))
+                .toList();
+    }
+
     public List<TopicResponse> findAllReadable(AuthMember authMember) {
         if (Objects.isNull(authMember.getMemberId())) {
             return getGuestTopicResponses(authMember);
@@ -99,13 +105,12 @@ public class TopicQueryService {
         return bookMarkedTopics.contains(topic);
     }
 
-
     public TopicDetailResponse findDetailById(AuthMember authMember, Long topicId) {
         Topic topic = findTopic(topicId);
         validateReadableTopic(authMember, topic);
 
         if (Objects.isNull(authMember.getMemberId())) {
-            return TopicDetailResponse.from(topic, Boolean.FALSE, Boolean.FALSE);
+            return TopicDetailResponse.from(topic, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE);
         }
 
         Member member = findMemberById(authMember.getMemberId());
@@ -116,7 +121,8 @@ public class TopicQueryService {
         return TopicDetailResponse.from(
                 topic,
                 isInAtlas(topicsInAtlas, topic),
-                isBookMarked(topicsInBookMark, topic)
+                isBookMarked(topicsInBookMark, topic),
+                authMember.canTopicUpdate(topic)
         );
     }
 
@@ -146,12 +152,6 @@ public class TopicQueryService {
         return getUserTopicDetailResponses(authMember, topics);
     }
 
-    private static List<TopicDetailResponse> getGuestTopicDetailResponses(List<Topic> topics) {
-        return topics.stream()
-                .map(topic -> TopicDetailResponse.from(topic, Boolean.FALSE, Boolean.FALSE))
-                .toList();
-    }
-
     private List<TopicDetailResponse> getUserTopicDetailResponses(AuthMember authMember, List<Topic> topics) {
         Member member = findMemberById(authMember.getMemberId());
 
@@ -162,7 +162,8 @@ public class TopicQueryService {
                 .map(topic -> TopicDetailResponse.from(
                         topic,
                         isInAtlas(topicsInAtlas, topic),
-                        isBookMarked(topicsInBookMark, topic)
+                        isBookMarked(topicsInBookMark, topic),
+                        authMember.canTopicUpdate(topic)
                 ))
                 .toList();
     }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
@@ -43,7 +43,7 @@ public class TopicQueryService {
 
     private static List<TopicDetailResponse> getGuestTopicDetailResponses(List<Topic> topics) {
         return topics.stream()
-                .map(topic -> TopicDetailResponse.from(topic, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE))
+                .map(topic -> TopicDetailResponse.of(topic, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE))
                 .toList();
     }
 
@@ -110,7 +110,7 @@ public class TopicQueryService {
         validateReadableTopic(authMember, topic);
 
         if (Objects.isNull(authMember.getMemberId())) {
-            return TopicDetailResponse.from(topic, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE);
+            return TopicDetailResponse.of(topic, Boolean.FALSE, Boolean.FALSE, Boolean.FALSE);
         }
 
         Member member = findMemberById(authMember.getMemberId());
@@ -118,7 +118,7 @@ public class TopicQueryService {
         List<Topic> topicsInAtlas = findTopicsInAtlas(member);
         List<Topic> topicsInBookMark = findBookMarkedTopics(member);
 
-        return TopicDetailResponse.from(
+        return TopicDetailResponse.of(
                 topic,
                 isInAtlas(topicsInAtlas, topic),
                 isBookMarked(topicsInBookMark, topic),
@@ -159,7 +159,7 @@ public class TopicQueryService {
         List<Topic> topicsInBookMark = findBookMarkedTopics(member);
 
         return topics.stream()
-                .map(topic -> TopicDetailResponse.from(
+                .map(topic -> TopicDetailResponse.of(
                         topic,
                         isInAtlas(topicsInAtlas, topic),
                         isBookMarked(topicsInBookMark, topic),

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
@@ -20,7 +20,7 @@ public record TopicDetailResponse(
         LocalDateTime updatedAt,
         List<PinResponse> pins
 ) {
-    public static TopicDetailResponse from(
+    public static TopicDetailResponse of(
             Topic topic,
             Boolean isInAtlas,
             Boolean isBookmarked,

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
@@ -16,7 +16,7 @@ public record TopicDetailResponse(
         Boolean isInAtlas,
         Integer bookmarkCount,
         Boolean isBookmarked,
-        Boolean hasUpdatePermission,
+        Boolean canUpdate,
         LocalDateTime updatedAt,
         List<PinResponse> pins
 ) {
@@ -24,7 +24,7 @@ public record TopicDetailResponse(
             Topic topic,
             Boolean isInAtlas,
             Boolean isBookmarked,
-            Boolean hasUpdatePermission
+            Boolean canUpdate
     ) {
         List<PinResponse> pinResponses = topic.getPins().stream()
                 .map(PinResponse::from)
@@ -42,7 +42,7 @@ public record TopicDetailResponse(
                 isInAtlas,
                 topic.countBookmarks(),
                 isBookmarked,
-                hasUpdatePermission,
+                canUpdate,
                 topic.getUpdatedAt(),
                 pinResponses
         );

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
@@ -16,10 +16,16 @@ public record TopicDetailResponse(
         Boolean isInAtlas,
         Integer bookmarkCount,
         Boolean isBookmarked,
+        Boolean hasUpdatePermission,
         LocalDateTime updatedAt,
         List<PinResponse> pins
 ) {
-    public static TopicDetailResponse from(Topic topic, Boolean isInAtlas, Boolean isBookmarked) {
+    public static TopicDetailResponse from(
+            Topic topic,
+            Boolean isInAtlas,
+            Boolean isBookmarked,
+            Boolean hasUpdatePermission
+    ) {
         List<PinResponse> pinResponses = topic.getPins().stream()
                 .map(PinResponse::from)
                 .toList();
@@ -36,6 +42,7 @@ public record TopicDetailResponse(
                 isInAtlas,
                 topic.countBookmarks(),
                 isBookmarked,
+                hasUpdatePermission,
                 topic.getUpdatedAt(),
                 pinResponses
         );

--- a/backend/src/test/java/com/mapbefine/mapbefine/location/presentation/LocationControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/location/presentation/LocationControllerTest.java
@@ -53,7 +53,7 @@ class LocationControllerTest extends RestDocsIntegration {
 
     @Test
     @DisplayName("현재 위치를 기준 토픽의 핀 개수로 나열한다.")
-    void findNearbyTopicsSortedByPinCount_Success() throws Exception {
+    void findNearbyTopicsSortedByPinCount() throws Exception {
         //given
         double latitude = 37;
         double longitude = 127;

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
@@ -91,7 +91,7 @@ class PinCommandServiceTest {
         assertThat(savedLocation.getId()).isEqualTo(location.getId());
         assertThat(actual).usingRecursiveComparison()
                 .ignoringFields("updatedAt")
-                .isEqualTo(PinDetailResponse.from(pin));
+                .isEqualTo(PinDetailResponse.of(pin, Boolean.TRUE));
     }
 
     @Test
@@ -121,7 +121,7 @@ class PinCommandServiceTest {
         assertThat(savedLocation.getId()).isNotEqualTo(location.getId());
         assertThat(actual).usingRecursiveComparison()
                 .ignoringFields("updatedAt")
-                .isEqualTo(PinDetailResponse.from(pin));
+                .isEqualTo(PinDetailResponse.of(pin, Boolean.TRUE));
 
         List<Location> locations = locationRepository.findAll();
         assertThat(locations).hasSize(2);
@@ -220,10 +220,10 @@ class PinCommandServiceTest {
 
         // then
         pinImageRepository.findById(pinImageId)
-                        .ifPresentOrElse(
-                                found -> assertThat(found.isDeleted()).isTrue(),
-                                Assertions::fail
-                        );
+                .ifPresentOrElse(
+                        found -> assertThat(found.isDeleted()).isTrue(),
+                        Assertions::fail
+                );
     }
 
     private long savePinImageAndGetId(long pinId) {

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinQueryServiceTest.java
@@ -108,7 +108,7 @@ class PinQueryServiceTest {
         // then
         assertThat(actual).usingRecursiveComparison()
                 .ignoringFields("updatedAt")
-                .isEqualTo(PinDetailResponse.from(pin));
+                .isEqualTo(PinDetailResponse.of(pin, Boolean.TRUE));
     }
 
     @Test

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/presentation/PinControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/presentation/PinControllerTest.java
@@ -93,6 +93,7 @@ class PinControllerTest extends RestDocsIntegration {
                 "매튜",
                 37,
                 127,
+                Boolean.FALSE,
                 LocalDateTime.now(),
                 List.of(new PinImageResponse(1L, BASE_IMAGES.get(0)))
         );

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
@@ -296,7 +296,7 @@ class TopicQueryServiceTest {
         assertThat(topicDetail.id()).isEqualTo(topic.getId());
         assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.TRUE);
         assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
-        assertThat(topicDetail.hasUpdatePermission()).isEqualTo(Boolean.TRUE);
+        assertThat(topicDetail.canUpdate()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
@@ -316,7 +316,7 @@ class TopicQueryServiceTest {
         assertThat(topicDetail.id()).isEqualTo(topic.getId());
         assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.FALSE);
         assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
-        assertThat(topicDetail.hasUpdatePermission()).isEqualTo(Boolean.FALSE);
+        assertThat(topicDetail.canUpdate()).isEqualTo(Boolean.FALSE);
     }
 
     @Test

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
@@ -235,7 +235,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("모든 토픽을 조회할 때, 즐겨찾기 여부를 함께 반환한다.")
-    public void findAllReadableWithBookmark_Success() {
+    void findAllReadableWithBookmark_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -258,7 +258,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("모든 토픽을 조회할 때, 로그인 유저가 아니면 즐겨찾기 여부가 항상 False다")
-    public void findAllReadableWithoutBookmark_Success() {
+    void findAllReadableWithoutBookmark_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -280,8 +280,8 @@ class TopicQueryServiceTest {
     }
 
     @Test
-    @DisplayName("토픽 상세조회시, 즐겨찾기 여부를 함께 반환한다.")
-    public void findWithBookmarkStatus_Success() {
+    @DisplayName("토픽 상세조회시, 즐겨찾기 여부, 모아보기 여부, 수정 권한 여부를 함께 반환한다.")
+    void findWithBookmarkStatus_Success() {
         //given
         Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
         topicRepository.save(topic);
@@ -295,12 +295,13 @@ class TopicQueryServiceTest {
 
         assertThat(topicDetail.id()).isEqualTo(topic.getId());
         assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.TRUE);
-
+        assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
+        assertThat(topicDetail.hasUpdatePermission()).isEqualTo(Boolean.TRUE);
     }
 
     @Test
-    @DisplayName("토픽 상세조회시, 로그인 유저가 아니라면 즐겨찾기 여부가 항상 False다.")
-    public void findWithoutBookmarkStatus_Success() {
+    @DisplayName("토픽 상세조회시, 로그인 유저가 아니라면 즐겨찾기 여부, 모아보기 여부, 수정 권한 여부가 항상 False다.")
+    void findWithoutBookmarkStatus_Success() {
         //given
         Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
         topicRepository.save(topic);
@@ -314,11 +315,13 @@ class TopicQueryServiceTest {
 
         assertThat(topicDetail.id()).isEqualTo(topic.getId());
         assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.FALSE);
+        assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
+        assertThat(topicDetail.hasUpdatePermission()).isEqualTo(Boolean.FALSE);
     }
 
     @Test
     @DisplayName("여러 토픽 조회시, 즐겨 찾기 여부를 함께 반환한다.")
-    public void findDetailsWithBookmarkStatus_Success() {
+    void findDetailsWithBookmarkStatus_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -342,7 +345,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("여러 토픽 조회시, 로그인 유저가 아니라면 즐겨 찾기 여부가 항상 False다.")
-    public void findDetailsWithoutBookmarkStatus_Success() {
+    void findDetailsWithoutBookmarkStatus_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -421,7 +424,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("즐겨찾기가 많이 있는 토픽 순서대로 조회할 수 있다.")
-    public void findAllBestTopics_Success1() {
+    void findAllBestTopics_Success1() {
         //given
         Member otherMember = MemberFixture.create(
                 "otherMember",
@@ -456,7 +459,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("즐겨찾기 순서대로 조회하더라도, private 토픽인 경우 조회할 수 없다.")
-    public void findAllBestTopics_Success2() {
+    void findAllBestTopics_Success2() {
         //given
         Member otherMember = MemberFixture.create(
                 "otherMember",

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/presentation/TopicControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/presentation/TopicControllerTest.java
@@ -160,6 +160,7 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
                 Boolean.FALSE,
                 0,
                 Boolean.FALSE,
+                Boolean.FALSE,
                 LocalDateTime.now(),
                 List.of(
                         new PinResponse(


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
- `토픽 상세 조회 API` : TopicDetailResponse, TopicController, TopicQueryService 및 관련 테스트코드
- `핀 상세 조회 API` : PinDetailResponse, PinController, PinQueryService 및 관련 테스트코드
- topic.adoc (Restdocs)

최대한 기존 코드를 변경하지 않는 방향으로, 상세 조회 시 즐겨찾기 여부를 담아주는 방식과 유사하게 작업했습니다. 

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
#390 참조 부탁드립니다. (변경된 API 예시도 기재해놓았습니다.)
- 추가로 Restdocs 문서 깨지는 부분을 수정하고, 가독성 향상을 위해 토픽 API 목차 순서와 네이밍을 조정했습니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->
<img width="191" alt="image" src="https://github.com/woowacourse-teams/2023-map-befine/assets/97426362/5140ba03-8d7d-478c-bd2e-b9060e5a54e8">


## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
#389
<!-- closed #번호 --> 
closed #390

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
