### PR TITLE
[BE] S3 를 통한 Image Upload 기능 구현

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
@@ -3,6 +3,7 @@ package com.mapbefine.mapbefine.pin.application;
 import static com.mapbefine.mapbefine.pin.exception.PinErrorCode.FORBIDDEN_PIN_CREATE_OR_UPDATE;
 import static com.mapbefine.mapbefine.pin.exception.PinErrorCode.ILLEGAL_PIN_ID;
 import static com.mapbefine.mapbefine.pin.exception.PinErrorCode.ILLEGAL_PIN_IMAGE_ID;
+import static com.mapbefine.mapbefine.s3.exception.S3ErrorCode.IMAGE_FILE_IS_NULL;
 import static com.mapbefine.mapbefine.topic.exception.TopicErrorCode.ILLEGAL_TOPIC_ID;
 
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
@@ -22,6 +23,7 @@ import com.mapbefine.mapbefine.pin.dto.request.PinUpdateRequest;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinBadRequestException;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
 import com.mapbefine.mapbefine.s3.application.S3Service;
+import com.mapbefine.mapbefine.s3.exception.S3Exception.S3BadRequestException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicBadRequestException;
@@ -78,10 +80,19 @@ public class PinCommandService {
                 member
         );
 
-        images.forEach(image -> addImageToPin(image, pin));
+        addPinImagesToPin(images, pin);
+
         pinRepository.save(pin);
 
         return pin.getId();
+    }
+
+    private void addPinImagesToPin(final List<MultipartFile> images, final Pin pin) {
+        if (Objects.isNull(images)) {
+            return;
+        }
+
+        images.forEach(image -> addImageToPin(image, pin));
     }
 
     private Topic findTopic(Long topicId) {
@@ -153,6 +164,10 @@ public class PinCommandService {
     }
 
     private void addImageToPin(MultipartFile image, Pin pin) {
+        if (Objects.isNull(image)) {
+            throw new S3BadRequestException(IMAGE_FILE_IS_NULL);
+        }
+
         String imageUrl = s3Service.upload(image);
         PinImage.createPinImageAssociatedWithPin(imageUrl, pin);
     }

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/presentation/PinController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/presentation/PinController.java
@@ -42,7 +42,7 @@ public class PinController {
     @PostMapping(consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE})
     public ResponseEntity<Void> add(
             AuthMember member,
-            @RequestPart List<MultipartFile> images,
+            @RequestPart(required = false) List<MultipartFile> images,
             @RequestPart PinCreateRequest request
     ) {
         long savedId = pinCommandService.save(member, images, request);
@@ -106,7 +106,7 @@ public class PinController {
     public ResponseEntity<Void> addImage(
             AuthMember member,
             @RequestPart Long pinId,
-            @RequestPart MultipartFile image
+            @RequestPart(required = false) MultipartFile image
     ) {
         pinCommandService.addImage(member, new PinImageCreateRequest(pinId, image));
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/application/S3ServiceImpl.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/application/S3ServiceImpl.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service
-@Profile("!test")
+@Profile("!test") // Test 시에는 TestS3ServiceImpl 를 Component 로 띄우기 위해 Profile 을 분리하였습니다.
 public class S3ServiceImpl implements S3Service {
 
     @Value("${prefix.upload.path}")
@@ -26,12 +26,12 @@ public class S3ServiceImpl implements S3Service {
             UploadFile uploadFile = UploadFile.from(multipartFile);
             s3Client.upload(uploadFile);
             return getUploadPath(uploadFile);
-        } catch (IOException exception) {
+        } catch (IOException exception) { // 이거 어떻게 처리해야할까요..
             throw new RuntimeException(exception);
         }
     }
 
-    private String getUploadPath(final UploadFile uploadFile) {
+    private String getUploadPath(UploadFile uploadFile) {
         return String.join(
                 "/",
                 prefixUploadPath,

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/domain/ImageExtension.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/domain/ImageExtension.java
@@ -1,0 +1,34 @@
+package com.mapbefine.mapbefine.s3.domain;
+
+import static com.mapbefine.mapbefine.s3.exception.S3ErrorCode.ILLEGAL_IMAGE_FILE_EXTENSION;
+
+import com.mapbefine.mapbefine.s3.exception.S3Exception.S3BadRequestException;
+import java.util.Arrays;
+
+public enum ImageExtension {
+
+    JPEG(".jpeg"),
+    JPG(".jpg"),
+    JFIF(".jfif"),
+    PNG(".png"),
+    SVG(".svg"),
+    ;
+
+    private final String extension;
+
+    ImageExtension(final String extension) {
+        this.extension = extension;
+    }
+
+    public static ImageExtension fromByImageFileName(String imageFileName) {
+        return Arrays.stream(values())
+                .filter(imageExtension -> imageFileName.endsWith(imageExtension.getExtension()))
+                .findFirst()
+                .orElseThrow(() -> new S3BadRequestException(ILLEGAL_IMAGE_FILE_EXTENSION));
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+}

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/domain/ImageName.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/domain/ImageName.java
@@ -6,7 +6,6 @@ import java.time.format.DateTimeFormatter;
 public class ImageName {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS");
-    private static final String EXTENSION_DELIMITER = ".";
 
     private final String fileName;
 
@@ -16,15 +15,13 @@ public class ImageName {
 
     public static ImageName from(String originalFileName) {
         String fileName = FORMATTER.format(LocalDateTime.now());
-        String extension = getExtension(originalFileName);
+        String extension = getExtension(originalFileName).getExtension();
 
         return new ImageName(fileName + extension);
     }
 
-    private static String getExtension(String originalFileName) {
-        return originalFileName.substring(
-                originalFileName.lastIndexOf(EXTENSION_DELIMITER)
-        );
+    private static ImageExtension getExtension(String originalFileName) {
+        return ImageExtension.fromByImageFileName(originalFileName);
     }
 
     public String getFileName() {

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/domain/S3Client.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/domain/S3Client.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -20,27 +21,32 @@ public class S3Client {
         this.amazonS3 = amazonS3;
     }
 
-    public void upload(MultipartFile multipartFile) {
+    public void upload(MultipartFile multipartFile) throws IOException {
         File tempFile = null;
 
         try {
             tempFile = File.createTempFile("upload_", ".tmp");
             multipartFile.transferTo(tempFile);
-            amazonS3.putObject(new PutObjectRequest(bucket, multipartFile.getOriginalFilename(), tempFile));
-        } catch (IOException e) { // TODO: 2023/09/07 Exception 을 수정
-            throw new RuntimeException(e);
+            amazonS3.putObject(new PutObjectRequest(
+                    bucket,
+                    multipartFile.getOriginalFilename(),
+                    tempFile
+            ));
+        } catch (IOException exception) {
+            throw new IOException(exception);
         } finally {
             removeTempFileIfExists(tempFile);
         }
     }
 
-    private void removeTempFileIfExists(final File tempFile) {
-        if (tempFile != null && tempFile.exists()) {
+    private void removeTempFileIfExists(File tempFile) {
+        if (!Objects.isNull(tempFile) && tempFile.exists()) {
             tempFile.delete();
         }
     }
 
     public void delete(String key) {
+        // 현재는 일단 기능만 만들어놓고, API 는 만들어놓지 않았습니다 회의를 통해서 결정해야 할 사항이 있는 것 같아서요!
         amazonS3.deleteObject(new DeleteObjectRequest(bucket, key));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3ErrorCode.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3ErrorCode.java
@@ -1,0 +1,19 @@
+package com.mapbefine.mapbefine.s3.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum S3ErrorCode {
+
+    ILLEGAL_IMAGE_FILE_EXTENSION("09000", "이미지 파일이 아닙니다.."),
+    ;
+
+    private final String code;
+    private final String message;
+
+    S3ErrorCode(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+}

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3ErrorCode.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3ErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum S3ErrorCode {
 
-    ILLEGAL_IMAGE_FILE_EXTENSION("09000", "이미지 파일이 아닙니다.."),
+    ILLEGAL_IMAGE_FILE_EXTENSION("09000", "이미지 파일이 아닙니다."),
     ;
 
     private final String code;

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3ErrorCode.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3ErrorCode.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 public enum S3ErrorCode {
 
     ILLEGAL_IMAGE_FILE_EXTENSION("09000", "이미지 파일이 아닙니다."),
+    IMAGE_FILE_IS_NULL("09001", "이미지가 선택되지 않았습니다.")
     ;
 
     private final String code;

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3Exception.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3Exception.java
@@ -10,6 +10,7 @@ public class S3Exception {
         public S3BadRequestException(S3ErrorCode errorCode) {
             super(new ErrorCode<>(errorCode.getCode(), errorCode.getMessage()));
         }
+
     }
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3Exception.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/s3/exception/S3Exception.java
@@ -1,0 +1,15 @@
+package com.mapbefine.mapbefine.s3.exception;
+
+import com.mapbefine.mapbefine.common.exception.BadRequestException;
+import com.mapbefine.mapbefine.common.exception.ErrorCode;
+
+public class S3Exception {
+
+    public static class S3BadRequestException extends BadRequestException {
+
+        public S3BadRequestException(S3ErrorCode errorCode) {
+            super(new ErrorCode<>(errorCode.getCode(), errorCode.getMessage()));
+        }
+    }
+
+}

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -34,7 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class TopicCommandService {
 
-    private static final String BASE_IMAGE_URL = "https://mapbefine.github.io/favicon.png";
+    private static final String BASE_IMAGE_URL = "https://map-befine-official.github.io/favicon.png";
 
     private final TopicRepository topicRepository;
     private final PinRepository pinRepository;

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -34,7 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class TopicCommandService {
 
-    private static final String BASE_IMAGE_URL = "https://map-befine-official.github.io/favicon.png";
+    private static final String BASE_IMAGE_URL = "https://velog.velcdn.com/images/semnil5202/post/37f3bcb9-0b07-4100-85f6-f1d5ad037c14/image.svg";
 
     private final TopicRepository topicRepository;
     private final PinRepository pinRepository;

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -28,10 +28,13 @@ import java.util.NoSuchElementException;
 import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @Service
 public class TopicCommandService {
+
+    private static final String BASE_IMAGE_URL = "https://mapbefine.github.io/favicon.png";
 
     private final TopicRepository topicRepository;
     private final PinRepository pinRepository;
@@ -54,7 +57,7 @@ public class TopicCommandService {
         Topic topic = convertToTopic(member, request);
         List<Long> pinIds = request.pins();
 
-        if (pinIds.size() > 0) {
+        if (0 < pinIds.size()) {
             copyPinsToTopic(member, topic, pinIds);
         }
 
@@ -65,7 +68,7 @@ public class TopicCommandService {
 
     private Topic convertToTopic(AuthMember member, TopicCreateRequest request) {
         Member creator = findCreatorByAuthMember(member);
-        String image = s3Service.upload(request.image());
+        String image = createImageUrl(request.image());
 
         return Topic.createTopicAssociatedWithCreator(
                 request.name(),
@@ -75,6 +78,14 @@ public class TopicCommandService {
                 request.permissionType(),
                 creator
         );
+    }
+
+    private String createImageUrl(MultipartFile image) {
+        if (Objects.isNull(image)) {
+            return BASE_IMAGE_URL;
+        }
+
+        return s3Service.upload(image);
     }
 
     private Member findCreatorByAuthMember(AuthMember member) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -34,8 +34,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 public class TopicCommandService {
 
-    private static final String BASE_IMAGE_URL = "https://velog.velcdn.com/images/semnil5202/post/37f3bcb9-0b07-4100-85f6-f1d5ad037c14/image.svg";
-
     private final TopicRepository topicRepository;
     private final PinRepository pinRepository;
     private final MemberRepository memberRepository;
@@ -82,7 +80,7 @@ public class TopicCommandService {
 
     private String createImageUrl(MultipartFile image) {
         if (Objects.isNull(image)) {
-            return BASE_IMAGE_URL;
+            return null;
         }
 
         return s3Service.upload(image);

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -148,11 +148,12 @@ public class TopicCommandService {
 
     private Topic convertToTopic(AuthMember member, TopicMergeRequest request) {
         Member creator = findCreatorByAuthMember(member);
+        String imageUrl = createImageUrl(request.image());
 
         return Topic.createTopicAssociatedWithCreator(
                 request.name(),
                 request.description(),
-                request.image(),
+                imageUrl,
                 request.publicity(),
                 request.permissionType(),
                 creator

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicInfo.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicInfo.java
@@ -21,8 +21,9 @@ import lombok.NoArgsConstructor;
 @Getter
 public class TopicInfo {
 
-    private static final Image DEFAULT_IMAGE =
-            Image.from("https://map-befine-official.github.io/favicon.png");
+    private static final Image DEFAULT_IMAGE = Image.from(
+            "https://velog.velcdn.com/images/semnil5202/post/37f3bcb9-0b07-4100-85f6-f1d5ad037c14/image.svg"
+    );
 
     private static final int MAX_DESCRIPTION_LENGTH = 1000;
     private static final int MAX_NAME_LENGTH = 20;

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicCreateRequest.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicCreateRequest.java
@@ -27,4 +27,5 @@ public record TopicCreateRequest(
                 request.pins()
         );
     }
+
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicCreateRequest.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicCreateRequest.java
@@ -15,7 +15,7 @@ public record TopicCreateRequest(
 ) {
 
     public static TopicCreateRequest of(
-            TopicCreateRequestWithOutImage request,
+            TopicCreateRequestWithoutImage request,
             MultipartFile image
     ) {
         return new TopicCreateRequest(

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicCreateRequestWithoutImage.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicCreateRequestWithoutImage.java
@@ -4,7 +4,7 @@ import com.mapbefine.mapbefine.topic.domain.PermissionType;
 import com.mapbefine.mapbefine.topic.domain.Publicity;
 import java.util.List;
 
-public record TopicCreateRequestWithOutImage(
+public record TopicCreateRequestWithoutImage(
         String name,
         String description,
         Publicity publicity,

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicMergeRequest.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicMergeRequest.java
@@ -3,13 +3,29 @@ package com.mapbefine.mapbefine.topic.dto.request;
 import com.mapbefine.mapbefine.topic.domain.PermissionType;
 import com.mapbefine.mapbefine.topic.domain.Publicity;
 import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
 
 public record TopicMergeRequest(
         String name,
-        String image,
+        MultipartFile image,
         String description,
         Publicity publicity,
         PermissionType permissionType,
         List<Long> topics
 ) {
+
+    public static TopicMergeRequest of(
+            TopicMergeRequestWithoutImage topicMergeRequestWithoutImage,
+            MultipartFile image
+    ) {
+        return new TopicMergeRequest(
+                topicMergeRequestWithoutImage.name(),
+                image,
+                topicMergeRequestWithoutImage.description(),
+                topicMergeRequestWithoutImage.publicity(),
+                topicMergeRequestWithoutImage.permissionType(),
+                topicMergeRequestWithoutImage.topics()
+        );
+    }
+
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicMergeRequestWithoutImage.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/request/TopicMergeRequestWithoutImage.java
@@ -1,0 +1,14 @@
+package com.mapbefine.mapbefine.topic.dto.request;
+
+import com.mapbefine.mapbefine.topic.domain.PermissionType;
+import com.mapbefine.mapbefine.topic.domain.Publicity;
+import java.util.List;
+
+public record TopicMergeRequestWithoutImage(
+        String name,
+        String description,
+        Publicity publicity,
+        PermissionType permissionType,
+        List<Long> topics
+) {
+}

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/exception/TopicErrorCode.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/exception/TopicErrorCode.java
@@ -4,21 +4,21 @@ import lombok.Getter;
 
 @Getter
 public enum TopicErrorCode {
-    ILLEGAL_TOPIC_ID("09000", "유효하지 않은 지도입니다."),
-    ILLEGAL_NAME_NULL("09001", "지도 이름은 필수로 입력해야합니다."),
-    ILLEGAL_NAME_LENGTH("09002", "지도 이름 길이는 최소 1자에서 20자여야 합니다."),
-    ILLEGAL_DESCRIPTION_NULL("09003", "지도 설명은 필수로 입력해야합니다."),
-    ILLEGAL_DESCRIPTION_LENGTH("09004", "지도 설명의 길이는 최소 1자에서 1000자여야 합니다."),
-    ILLEGAL_PUBLICITY_NULL("09005", "지도의 공개 범위는 필수로 입력해야합니다."),
-    ILLEGAL_PERMISSION_NULL("09006", "지도의 권한 설정은 필수로 입력해야합니다."),
-    ILLEGAL_PERMISSION_FOR_PUBLICITY_PRIVATE("09007", "비공개 지도인 경우, 권한 설정이 소속 회원이어야합니다."),
-    ILLEGAL_PUBLICITY_FOR_PERMISSION_ALL_MEMBERS("09008", "권한 범위가 모든 회원인 경우, 비공개 지도로 설정할 수 없습니다."),
-    ILLEGAL_PERMISSION_UPDATE("09009", "권한 범위를 모든 회원에서 소속 회원으로 수정할 수 없습니다."),
-    FORBIDDEN_TOPIC_CREATE("09300", "로그인하지 않은 사용자는 지도를 생성할 수 없습니다."),
-    FORBIDDEN_TOPIC_UPDATE("09301", "지도 수정 권한이 없습니다."),
-    FORBIDDEN_TOPIC_DELETE("09302", "지도 삭제 권한이 없습니다."),
-    FORBIDDEN_TOPIC_READ("09302", "지도 조회 권한이 없습니다."),
-    TOPIC_NOT_FOUND("09400", "지도가 존재하지 않습니다."),
+    ILLEGAL_TOPIC_ID("10000", "유효하지 않은 지도입니다."),
+    ILLEGAL_NAME_NULL("10001", "지도 이름은 필수로 입력해야합니다."),
+    ILLEGAL_NAME_LENGTH("10002", "지도 이름 길이는 최소 1자에서 20자여야 합니다."),
+    ILLEGAL_DESCRIPTION_NULL("10003", "지도 설명은 필수로 입력해야합니다."),
+    ILLEGAL_DESCRIPTION_LENGTH("10004", "지도 설명의 길이는 최소 1자에서 1000자여야 합니다."),
+    ILLEGAL_PUBLICITY_NULL("10005", "지도의 공개 범위는 필수로 입력해야합니다."),
+    ILLEGAL_PERMISSION_NULL("10006", "지도의 권한 설정은 필수로 입력해야합니다."),
+    ILLEGAL_PERMISSION_FOR_PUBLICITY_PRIVATE("10007", "비공개 지도인 경우, 권한 설정이 소속 회원이어야합니다."),
+    ILLEGAL_PUBLICITY_FOR_PERMISSION_ALL_MEMBERS("10008", "권한 범위가 모든 회원인 경우, 비공개 지도로 설정할 수 없습니다."),
+    ILLEGAL_PERMISSION_UPDATE("10009", "권한 범위를 모든 회원에서 소속 회원으로 수정할 수 없습니다."),
+    FORBIDDEN_TOPIC_CREATE("10300", "로그인하지 않은 사용자는 지도를 생성할 수 없습니다."),
+    FORBIDDEN_TOPIC_UPDATE("10301", "지도 수정 권한이 없습니다."),
+    FORBIDDEN_TOPIC_DELETE("10302", "지도 삭제 권한이 없습니다."),
+    FORBIDDEN_TOPIC_READ("10302", "지도 조회 권한이 없습니다."),
+    TOPIC_NOT_FOUND("10400", "지도가 존재하지 않습니다."),
     ;
 
     private final String code;

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
@@ -49,7 +49,7 @@ public class TopicController {
     public ResponseEntity<Void> create(
             AuthMember member,
             @RequestPart TopicCreateRequestWithOutImage request,
-            @RequestPart MultipartFile image
+            @RequestPart(required = false) MultipartFile image
     ) {
         TopicCreateRequest topicCreateRequest = TopicCreateRequest.of(request, image);
         Long topicId = topicCommandService.saveTopic(member, topicCreateRequest);

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
@@ -5,8 +5,9 @@ import com.mapbefine.mapbefine.common.interceptor.LoginRequired;
 import com.mapbefine.mapbefine.topic.application.TopicCommandService;
 import com.mapbefine.mapbefine.topic.application.TopicQueryService;
 import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequest;
-import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequestWithOutImage;
+import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequestWithoutImage;
 import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequest;
+import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequestWithoutImage;
 import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
@@ -48,7 +49,7 @@ public class TopicController {
     )
     public ResponseEntity<Void> create(
             AuthMember member,
-            @RequestPart TopicCreateRequestWithOutImage request,
+            @RequestPart TopicCreateRequestWithoutImage request,
             @RequestPart(required = false) MultipartFile image
     ) {
         TopicCreateRequest topicCreateRequest = TopicCreateRequest.of(request, image);
@@ -59,9 +60,17 @@ public class TopicController {
     }
 
     @LoginRequired
-    @PostMapping("/merge")
-    public ResponseEntity<Void> mergeAndCreate(AuthMember member, @RequestBody TopicMergeRequest request) {
-        Long topicId = topicCommandService.merge(member, request);
+    @PostMapping(
+            value = "/merge",
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE, MediaType.APPLICATION_JSON_VALUE}
+    )
+    public ResponseEntity<Void> mergeAndCreate(
+            AuthMember member,
+            @RequestPart TopicMergeRequestWithoutImage request,
+            @RequestPart(required = false) MultipartFile image
+    ) {
+        TopicMergeRequest topicMergeRequest = TopicMergeRequest.of(request, image);
+        Long topicId = topicCommandService.merge(member, topicMergeRequest);
 
         return ResponseEntity.created(URI.create("/topics/" + topicId))
                 .build();

--- a/backend/src/test/java/com/mapbefine/mapbefine/TestS3ServiceImpl.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/TestS3ServiceImpl.java
@@ -11,7 +11,7 @@ public class TestS3ServiceImpl implements S3Service {
 
     @Override
     public String upload(MultipartFile multipartFile) {
-        return "https://mapbefine.github.io/favicon.png";
+        return "https://map-befine-official.github.io/favicon.png";
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/TestS3ServiceImpl.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/TestS3ServiceImpl.java
@@ -11,7 +11,6 @@ public class TestS3ServiceImpl implements S3Service {
 
     @Override
     public String upload(MultipartFile multipartFile) {
-        System.out.println("TestS3ServiceImple Upload Method Called !!!!!!!!!!!!!!!!!!!!!!!!!!!!");
         return "https://mapbefine.github.io/favicon.png";
     }
 

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
@@ -194,8 +194,9 @@ class AdminCommandServiceTest {
         //then
         Topic imageDeletedTopic = topicRepository.findById(topic.getId()).get();
 
-        assertThat(imageDeletedTopic.getTopicInfo().getImageUrl())
-                .isEqualTo("https://map-befine-official.github.io/favicon.png");
+        assertThat(imageDeletedTopic.getTopicInfo().getImageUrl()).isEqualTo(
+                "https://velog.velcdn.com/images/semnil5202/post/37f3bcb9-0b07-4100-85f6-f1d5ad037c14/image.svg"
+        );
     }
 
     @DisplayName("Admin이 아닐 경우, 이미지를 삭제할 수 없다.")

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/PinIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/PinIntegrationTest.java
@@ -160,7 +160,6 @@ class PinIntegrationTest extends IntegrationTest {
         ExtractableResponse<Response> response = findById(pinId);
 
         PinDetailResponse as = response.as(PinDetailResponse.class);
-        System.out.println(as);
 
         // then
         assertThat(response.jsonPath().getString("name"))
@@ -194,8 +193,6 @@ class PinIntegrationTest extends IntegrationTest {
 
         // when
         ExtractableResponse<Response> response = createPinImage(pinId);
-
-        System.out.println(response);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/PinIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/PinIntegrationTest.java
@@ -115,6 +115,23 @@ class PinIntegrationTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("Image List 없이 Pin 을 정상적으로 생성한다.")
+    void addIfNonExistImageList_Success() {
+        // when
+        ExtractableResponse<Response> response = RestAssured.given()
+                .log().all()
+                .header(AUTHORIZATION, authHeader)
+                .multiPart("request", createRequestDuplicateLocation, MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/pins")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.header("Location")).isNotBlank();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    @Test
     @DisplayName("Pin을 생성하면 저장된 Pin의 Location 헤더값과 201을 반환한다.")
     void addIfNotExistDuplicateLocation_Success() {
         //given, when

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
@@ -1,5 +1,6 @@
 package com.mapbefine.mapbefine.pin.application;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -25,6 +26,7 @@ import com.mapbefine.mapbefine.pin.dto.request.PinUpdateRequest;
 import com.mapbefine.mapbefine.pin.dto.response.PinDetailResponse;
 import com.mapbefine.mapbefine.pin.dto.response.PinImageResponse;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
+import com.mapbefine.mapbefine.s3.exception.S3Exception.S3BadRequestException;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
@@ -197,6 +199,19 @@ class PinCommandServiceTest {
                         found -> assertThat(found.getImageUrl()).isNotNull(),
                         Assertions::fail
                 );
+    }
+
+    @Test
+    @DisplayName("이미지가 null 인 경우 예외를 발생시킨다.")
+    void addImage_FailByNull() {
+        // given
+        long pinId = pinCommandService.save(authMember, List.of(BASE_IMAGE_FILE), createRequest);
+
+        PinImageCreateRequest imageNullRequest = new PinImageCreateRequest(pinId, null);
+
+        // when then
+        assertThatThrownBy(() -> pinCommandService.addImage(authMember, imageNullRequest))
+                .isInstanceOf(S3BadRequestException.class);
     }
 
     @Test

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/presentation/PinControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/presentation/PinControllerTest.java
@@ -40,7 +40,10 @@ class PinControllerTest extends RestDocsIntegration {
     @DisplayName("핀 추가")
     void add() throws Exception {
         given(pinCommandService.save(any(), any(), any())).willReturn(1L);
-        File mockFile = new File(getClass().getClassLoader().getResource("test.png").getPath());
+        File mockFile = new File(getClass()
+                .getClassLoader()
+                .getResource("test.png")
+                .getPath());
         MultiValueMap<String, Object> param = new LinkedMultiValueMap<>();
 
         PinCreateRequest pinCreateRequest = new PinCreateRequest(
@@ -158,11 +161,6 @@ class PinControllerTest extends RestDocsIntegration {
                 .getResource("test.png")
                 .getPath();
         File mockFile = new File(imageFilePath);
-
-//        PinImageCreateRequest pinImageCreateRequest = new PinImageCreateRequest(
-//                1L,
-//                FileFixture.createFile()
-//        );
 
         mockMvc.perform(
                 MockMvcRequestBuilders.post("/pins/images")

--- a/backend/src/test/java/com/mapbefine/mapbefine/s3/ImageExtensionTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/s3/ImageExtensionTest.java
@@ -1,0 +1,36 @@
+package com.mapbefine.mapbefine.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mapbefine.mapbefine.s3.domain.ImageExtension;
+import com.mapbefine.mapbefine.s3.exception.S3Exception.S3BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ImageExtensionTest {
+
+    @DisplayName("fromByImageFileName 를 통해 정상적으로 ImageExtension 을 생성한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"image.jpeg", "image.jpg", "image.jfif", "image.png", "image.svg"})
+    void createImageExtensionByFileName_Success(String fileName) {
+        // given when
+        String extension = ImageExtension.fromByImageFileName(fileName)
+                .getExtension();
+
+        // then
+        assertThat(fileName).contains(extension);
+    }
+
+    @DisplayName("fromByImageFileName 을 통해 존재하지 않는 확장자라면 예외가 발생한다.")
+    @ParameterizedTest
+    @ValueSource(strings = {"image.pppng", "image.jpeeg", "image.gi"})
+    void createImageExtensionByFileName_Fail(String fileName) {
+        // given when then
+        assertThatThrownBy(() -> ImageExtension.fromByImageFileName(fileName))
+                .isInstanceOf(S3BadRequestException.class);
+    }
+
+}

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicFixture.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicFixture.java
@@ -89,7 +89,7 @@ public class TopicFixture {
     ) {
         return new TopicMergeRequest(
                 "아무나 읽을 수 있는 토픽",
-                IMAGE_URL,
+                FileFixture.createFile(),
                 "아무나 읽을 수 있는 토픽입니다.",
                 Publicity.PUBLIC,
                 PermissionType.ALL_MEMBERS,

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicFixture.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicFixture.java
@@ -40,7 +40,7 @@ public class TopicFixture {
         return Topic.createTopicAssociatedWithCreator(
                 name,
                 "설명",
-                null,
+                IMAGE_URL,
                 Publicity.PUBLIC,
                 PermissionType.ALL_MEMBERS,
                 member
@@ -51,7 +51,7 @@ public class TopicFixture {
         return Topic.createTopicAssociatedWithCreator(
                 name,
                 "설명",
-                null,
+                IMAGE_URL,
                 Publicity.PRIVATE,
                 PermissionType.GROUP_ONLY,
                 member
@@ -64,7 +64,19 @@ public class TopicFixture {
         return new TopicCreateRequest(
                 "아무나 읽을 수 있는 토픽",
                 FileFixture.createFile(),
-//                IMAGE_URL,
+                "아무나 읽을 수 있는 토픽입니다.",
+                Publicity.PUBLIC,
+                PermissionType.ALL_MEMBERS,
+                pinIds
+        );
+    }
+
+    public static TopicCreateRequest createPublicAndAllMembersAndEmptyImageCreateRequestWithPins(
+            List<Long> pinIds
+    ) {
+        return new TopicCreateRequest(
+                "아무나 읽을 수 있는 토픽",
+                null,
                 "아무나 읽을 수 있는 토픽입니다.",
                 Publicity.PUBLIC,
                 PermissionType.ALL_MEMBERS,

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
@@ -92,13 +92,6 @@ class TopicIntegrationTest extends IntegrationTest {
                 .getResource("test.png")
                 .getPath();
         File mockFile = new File(imageFilePath);
-        
-//        MockMultipartFile mockFile = new MockMultipartFile( // 이것은 왜 그런 것일까??
-//                "test",
-//                "test.png",
-//                "image/png",
-//                "byteCode".getBytes()
-//        );
 
         return RestAssured.given()
                 .log().all()

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
@@ -20,8 +20,9 @@ import com.mapbefine.mapbefine.topic.domain.PermissionType;
 import com.mapbefine.mapbefine.topic.domain.Publicity;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequestWithOutImage;
+import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequestWithoutImage;
 import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequest;
+import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequestWithoutImage;
 import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
@@ -59,6 +60,7 @@ class TopicIntegrationTest extends IntegrationTest {
     private Topic topic;
     private Location location;
     private String authHeader;
+    private File mockFile;
 
     @BeforeEach
     void setMember() {
@@ -66,13 +68,18 @@ class TopicIntegrationTest extends IntegrationTest {
         topic = topicRepository.save(TopicFixture.createPublicAndAllMembersTopic(member));
         location = locationRepository.save(LocationFixture.create());
         authHeader = testAuthHeaderProvider.createAuthHeader(member);
-    }
+        mockFile = new File(
+                getClass().getClassLoader()
+                        .getResource("test.png")
+                        .getPath()
+        );
 
+    }
 
     @Test
     @DisplayName("Pin 목록 없이 Topic을 생성하면 201을 반환한다")
     void createNewTopicWithoutPins_Success() {
-        TopicCreateRequestWithOutImage 준팍의_또간집 = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage 준팍의_또간집 = new TopicCreateRequestWithoutImage(
                 "준팍의 또간집",
                 "준팍이 2번 이상 간집 ",
                 Publicity.PUBLIC,
@@ -88,12 +95,7 @@ class TopicIntegrationTest extends IntegrationTest {
         assertThat(response.header("Location")).isNotBlank();
     }
 
-    private ExtractableResponse<Response> createNewTopic(TopicCreateRequestWithOutImage request, String authHeader) {
-        String imageFilePath = getClass().getClassLoader()
-                .getResource("test.png")
-                .getPath();
-        File mockFile = new File(imageFilePath);
-
+    private ExtractableResponse<Response> createNewTopic(TopicCreateRequestWithoutImage request, String authHeader) {
         return RestAssured.given()
                 .log().all()
                 .header(AUTHORIZATION, authHeader)
@@ -104,7 +106,7 @@ class TopicIntegrationTest extends IntegrationTest {
                 .extract();
     }
 
-    private ExtractableResponse<Response> createNewTopicExcludeImage(TopicCreateRequestWithOutImage request, String authHeader) {
+    private ExtractableResponse<Response> createNewTopicExcludeImage(TopicCreateRequestWithoutImage request, String authHeader) {
         return RestAssured.given()
                 .log().all()
                 .header(AUTHORIZATION, authHeader)
@@ -124,7 +126,7 @@ class TopicIntegrationTest extends IntegrationTest {
                 .map(Pin::getId)
                 .toList();
 
-        TopicCreateRequestWithOutImage 준팍의_또간집 = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage 준팍의_또간집 = new TopicCreateRequestWithoutImage(
                 "준팍의 또간집",
                 "준팍이 2번 이상 간집 ",
                 Publicity.PUBLIC,
@@ -150,7 +152,7 @@ class TopicIntegrationTest extends IntegrationTest {
                 .map(Pin::getId)
                 .toList();
 
-        TopicCreateRequestWithOutImage 준팍의_또간집 = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage 준팍의_또간집 = new TopicCreateRequestWithoutImage(
                 "준팍의 또간집",
                 "준팍이 2번 이상 간집 ",
                 Publicity.PUBLIC,
@@ -170,14 +172,14 @@ class TopicIntegrationTest extends IntegrationTest {
     @DisplayName("여러개의 토픽을 병합하면 201을 반환한다")
     void createMergeTopic_Success() {
         // given
-        TopicCreateRequestWithOutImage 준팍의_또간집 = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage 준팍의_또간집 = new TopicCreateRequestWithoutImage(
                 "준팍의 또간집",
                 "준팍이 2번 이상 간집 ",
                 Publicity.PUBLIC,
                 PermissionType.ALL_MEMBERS,
                 Collections.emptyList()
         );
-        TopicCreateRequestWithOutImage 준팍의_또안간집 = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage 준팍의_또안간집 = new TopicCreateRequestWithoutImage(
                 "준팍의 또안간집",
                 "준팍이 2번 이상 안간집 ",
                 Publicity.PUBLIC,
@@ -191,20 +193,65 @@ class TopicIntegrationTest extends IntegrationTest {
                 .map(Topic::getId)
                 .toList();
 
-        TopicMergeRequest 송파_데이트코스 = new TopicMergeRequest(
+        TopicMergeRequestWithoutImage 송파_데이트코스 = new TopicMergeRequestWithoutImage(
                 "송파 데이트코스",
-                "https://map-befine-official.github.io/favicon.png",
                 "맛집과 카페 토픽 합치기",
                 Publicity.PUBLIC,
                 PermissionType.ALL_MEMBERS,
                 topicIds);
 
         // when
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
+        ExtractableResponse<Response> response = RestAssured.given()
+                .log().all()
                 .header(AUTHORIZATION, authHeader)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(송파_데이트코스)
+                .multiPart("image", mockFile, MediaType.MULTIPART_FORM_DATA_VALUE)
+                .multiPart("request", 송파_데이트코스, MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/topics/merge")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("여러개의 토픽을 토픽 이미지 없이 병합해도 201을 반환한다")
+    void createMergeTopicWithoutImage_Success() {
+        // given
+        TopicCreateRequestWithoutImage 준팍의_또간집 = new TopicCreateRequestWithoutImage(
+                "준팍의 또간집",
+                "준팍이 2번 이상 간집 ",
+                Publicity.PUBLIC,
+                PermissionType.ALL_MEMBERS,
+                Collections.emptyList()
+        );
+        TopicCreateRequestWithoutImage 준팍의_또안간집 = new TopicCreateRequestWithoutImage(
+                "준팍의 또안간집",
+                "준팍이 2번 이상 안간집 ",
+                Publicity.PUBLIC,
+                PermissionType.ALL_MEMBERS,
+                Collections.emptyList()
+        );
+        createNewTopic(준팍의_또간집, authHeader);
+        createNewTopic(준팍의_또안간집, authHeader);
+        List<Topic> topics = topicRepository.findAll();
+        List<Long> topicIds = topics.stream()
+                .map(Topic::getId)
+                .toList();
+
+        TopicMergeRequestWithoutImage 송파_데이트코스 = new TopicMergeRequestWithoutImage(
+                "송파 데이트코스",
+                "맛집과 카페 토픽 합치기",
+                Publicity.PUBLIC,
+                PermissionType.ALL_MEMBERS,
+                topicIds);
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given()
+                .log().all()
+                .header(AUTHORIZATION, authHeader)
+                .multiPart("request", 송파_데이트코스, MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/topics/merge")
                 .then().log().all()
                 .extract();
@@ -218,7 +265,7 @@ class TopicIntegrationTest extends IntegrationTest {
     @DisplayName("Topic을 수정하면 200을 반환한다")
     void updateTopic_Success() {
         ExtractableResponse<Response> newTopic = createNewTopic(
-                new TopicCreateRequestWithOutImage(
+                new TopicCreateRequestWithoutImage(
                         "준팍의 또간집",
                         "준팍이 두번 간집",
                         Publicity.PUBLIC,
@@ -254,7 +301,7 @@ class TopicIntegrationTest extends IntegrationTest {
     @DisplayName("Topic을 삭제하면 204를 반환한다")
     void deleteTopic_Success() {
         ExtractableResponse<Response> newTopic = createNewTopic(
-                new TopicCreateRequestWithOutImage(
+                new TopicCreateRequestWithoutImage(
                         "준팍의 또간집",
                         "준팍이 두번 간집 ",
                         Publicity.PUBLIC,
@@ -298,7 +345,7 @@ class TopicIntegrationTest extends IntegrationTest {
     @DisplayName("Topic 상세 정보를 조회하면 200을 반환한다")
     void findTopicDetail_Success() {
         //given
-        TopicCreateRequestWithOutImage request = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage request = new TopicCreateRequestWithoutImage(
                 "topicName",
                 "description",
                 Publicity.PUBLIC,
@@ -326,7 +373,7 @@ class TopicIntegrationTest extends IntegrationTest {
     @DisplayName("Topic 상세 정보 여러개를 조회하면 200을 반환한다")
     void findTopicDetailsByIds_Success() {
         //given
-        TopicCreateRequestWithOutImage request = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage request = new TopicCreateRequestWithoutImage(
                 "topicName",
                 "description",
                 Publicity.PUBLIC,

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
@@ -73,7 +73,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("비어있는 토픽을 생성할 수 있다.")
-    public void saveEmptyTopic_Success() {
+    void saveEmptyTopic_Success() {
         //given
         TopicCreateRequest request =
                 TopicFixture.createPublicAndAllMembersCreateRequestWithPins(
@@ -93,8 +93,30 @@ class TopicCommandServiceTest {
     }
 
     @Test
+    @DisplayName("이미지 없이 토픽을 생성하면 기본 이미지를 반환한다.")
+    void saveEmptyTopicAndEmptyImage_Success() {
+        //given
+        TopicCreateRequest request =
+                TopicFixture.createPublicAndAllMembersAndEmptyImageCreateRequestWithPins(
+                        Collections.emptyList()
+                );
+
+        //when
+        Long topicId = topicCommandService.saveTopic(user, request);
+
+        //then
+        TopicDetailResponse detail = topicQueryService.findDetailById(user, topicId);
+
+        assertThat(detail.id()).isEqualTo(topicId);
+        assertThat(detail.name()).isEqualTo(request.name());
+        assertThat(detail.description()).isEqualTo(request.description());
+        assertThat(detail.pinCount()).isEqualTo(request.pins().size());
+        assertThat(detail.image()).isEqualTo("https://map-befine-official.github.io/favicon.png");
+    }
+
+    @Test
     @DisplayName("Guest는 비어있는 토픽을 생성할 수 없다.")
-    public void saveEmptyTopic_Fail() {
+    void saveEmptyTopic_Fail() {
         //given
         TopicCreateRequest request =
                 TopicFixture.createPublicAndAllMembersCreateRequestWithPins(
@@ -108,7 +130,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("핀을 통해 새로운 토픽을 생성할 수 있다.")
-    public void saveTopicWithPins_Success() {
+    void saveTopicWithPins_Success() {
         //given
         Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
 
@@ -139,7 +161,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("Guest는 핀을 통해 새로운 토픽을 생성할 수 없다.")
-    public void saveTopicWithPins_Fail1() {
+    void saveTopicWithPins_Fail1() {
         //given
         Topic publicAndAllMembersTopic = TopicFixture.createPublicAndAllMembersTopic(member);
 
@@ -160,7 +182,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("권한이 없는 핀을 통해 토픽을 생성할 수 없다.")
-    public void saveTopicWithPins_Fail2() {
+    void saveTopicWithPins_Fail2() {
         //given
         Member topicOwner = MemberFixture.create(
                 "topicOwner",
@@ -187,7 +209,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("기존의 토픽들을 통해 새로운 토픽을 생성할 수 있다.")
-    public void merge_Success() {
+    void merge_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -224,7 +246,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("Guest는 기존의 토픽들을 통해 새로운 토픽을 생성할 수 없다.")
-    public void merge_Fail1() {
+    void merge_Fail1() {
         //given
         Topic privateAndGroupOnlyTopic = TopicFixture.createPrivateAndGroupOnlyTopic(member);
         topicRepository.save(privateAndGroupOnlyTopic);
@@ -241,7 +263,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("권한이 없는 토픽들을 통해 새로운 토픽을 생성할 수 없다.")
-    public void merge_Fail2() {
+    void merge_Fail2() {
         //given
         Member topicOwner = MemberFixture.create(
                 "topicOwner",
@@ -297,7 +319,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("토픽의 정보를 수정할 수 있다.")
-    public void updateTopicInfo_Success() {
+    void updateTopicInfo_Success() {
         //given
         Topic topic = TopicFixture.createPrivateAndGroupOnlyTopic(member);
         topicRepository.save(topic);
@@ -326,7 +348,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("권한이 없는 토픽의 정보를 수정할 수 없다.")
-    public void updateTopicInfo_Fail() {
+    void updateTopicInfo_Fail() {
         //given
         Member topicOwner = MemberFixture.create(
                 "topicOwner",
@@ -353,7 +375,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("Admin은 토픽을 삭제할 수 있다.")
-    public void delete_Success() {
+    void delete_Success() {
         //given
         Member admin = MemberFixture.create(
                 "topicOwner",
@@ -380,7 +402,7 @@ class TopicCommandServiceTest {
 
     @Test
     @DisplayName("Admin이 아닌 경우, 토픽을 삭제할 수 없다.")
-    public void delete_Fail() {
+    void delete_Fail() {
         //given
         Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
         topicRepository.save(topic);

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
@@ -111,7 +111,9 @@ class TopicCommandServiceTest {
         assertThat(detail.name()).isEqualTo(request.name());
         assertThat(detail.description()).isEqualTo(request.description());
         assertThat(detail.pinCount()).isEqualTo(request.pins().size());
-        assertThat(detail.image()).isEqualTo("https://map-befine-official.github.io/favicon.png");
+        assertThat(detail.image()).isEqualTo(
+                "https://velog.velcdn.com/images/semnil5202/post/37f3bcb9-0b07-4100-85f6-f1d5ad037c14/image.svg"
+        );
     }
 
     @Test

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicInfoTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicInfoTest.java
@@ -116,7 +116,8 @@ class TopicInfoTest {
         assertThat(topicInfo.getName()).isEqualTo(validName);
         assertThat(topicInfo.getDescription()).isEqualTo(validDescription);
         assertThat(topicInfo.getImageUrl()).isEqualTo(
-                "https://map-befine-official.github.io/favicon.png");
+                "https://velog.velcdn.com/images/semnil5202/post/37f3bcb9-0b07-4100-85f6-f1d5ad037c14/image.svg"
+        );
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/presentation/TopicControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/presentation/TopicControllerTest.java
@@ -10,14 +10,15 @@ import com.mapbefine.mapbefine.topic.application.TopicCommandService;
 import com.mapbefine.mapbefine.topic.application.TopicQueryService;
 import com.mapbefine.mapbefine.topic.domain.PermissionType;
 import com.mapbefine.mapbefine.topic.domain.Publicity;
-import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequestWithOutImage;
-import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequest;
+import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequestWithoutImage;
+import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequestWithoutImage;
 import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
 import java.io.File;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -50,10 +51,21 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
             LocalDateTime.now()
     ));
 
+    private File mockFile;
+
     @MockBean
     private TopicCommandService topicCommandService;
     @MockBean
     private TopicQueryService topicQueryService;
+
+    @BeforeEach
+    void setUp() {
+        mockFile = new File(
+                getClass().getClassLoader()
+                        .getResource("test.png")
+                        .getPath()
+        );
+    }
 
 
     @Test
@@ -63,7 +75,7 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
         File mockFile = new File(getClass().getClassLoader().getResource("test.png").getPath());
         MultiValueMap<String, Object> param = new LinkedMultiValueMap<>();
 
-        TopicCreateRequestWithOutImage request = new TopicCreateRequestWithOutImage(
+        TopicCreateRequestWithoutImage request = new TopicCreateRequestWithoutImage(
                 "준팍의 안갈집",
                 "준팍이 두번 다시 안갈집",
                 Publicity.PUBLIC,
@@ -78,30 +90,34 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
                 MockMvcRequestBuilders.post("/topics/new")
                         .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
                         .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .content(objectMapper.writeValueAsString(mockFile))
+                        .content(objectMapper.writeValueAsString(param))
         ).andDo(restDocs.document());
     }
 
     @Test
     @DisplayName("토픽 병합 생성")
     void mergeAndCreate() throws Exception {
-
         given(topicCommandService.merge(any(), any())).willReturn(1L);
 
-        TopicMergeRequest topicMergeRequest = new TopicMergeRequest(
+        MultiValueMap<String, Object> param = new LinkedMultiValueMap<>();
+
+
+        TopicMergeRequestWithoutImage request = new TopicMergeRequestWithoutImage(
                 "준팍의 안갈집",
-                "https://map-befine-official.github.io/favicon.png",
                 "준팍이 두번 다시 안갈집",
                 Publicity.PUBLIC,
                 PermissionType.ALL_MEMBERS,
                 List.of(1L, 2L, 3L)
         );
 
+        param.add("image", mockFile);
+        param.add("request", request);
+
         mockMvc.perform(
                 MockMvcRequestBuilders.post("/topics/merge")
                         .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(topicMergeRequest))
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+                        .content(objectMapper.writeValueAsString(param))
         ).andDo(restDocs.document());
     }
 


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->

Image 를 Upload 하는 API 수정

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->

- POST /pins (핀 생성과 함께 Image 리스트를 받을 수 있도록 수정)
- POST /pins/images (Pin 에 단일 이미지를 추가하는 기능)
- POST /topics/new 
- POST /topics/merge

1. 기존에 위 API 들 모두 String 으로 Image URL 을 받고 있었는데, 해당 부분을 `MultipartFile` 를 받을 수 있도록 수정
2. 받은 MultipartFile 을 AWS S3 2023/team-projects/2023-map-be-fine/(dev, prod) 에 upload
3. cloud front url + "/" + 생성한 image name 으로 DB 에 Image URL 저장
4. DB 에 저장된 Image URL 로 S3 에 올라가 있는 Image 로 접근가능

이 이외에 이해가 안되는 부분이 있다면 질문 남겨주시면 감사할 것 같아요!

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

이야기 해봐야 할 사항들이 조금 있는 것 같아요! 이야기 해본 다음 제가 계속해서 보완해나가도록 하겠습니다.

- DB 에 저장해야 할 내용은 Image URL 이라고 생각하시나요? 아니면 fileName 이름이라고 생각하시나요? ex) imageURL -> `https://.../imageName.png`, image 이름 -> `imageName.png`
	- Image URL 을 저장한다면?
		- S3 에 이미지를 올린 데이터의 경우에는 그냥 끝에 fileName 만 따서 삭제하면 됩니다. 이건 쉬워요 ex ) url 은 `cloud front url + "/" + fileName` 이니까 file name 만 따서 S3 에 삭제요청 날리면됩니다. 
	- fileName 을 선택한다면?
		- fileName 을 저장하는 것을 선택한다면, 기존의 데이터를 활용하지 못할 것 같아요.
		- Image 이름을 DB 에 저장한다면, 실제로 이미지에 접근할 때 `cloud front url` 을 `prefix` 에 붙여야 하는데, 기존의 데이터들은 `https://...` 이렇게 저장되어 있어, `cloud front url + https://...` 로 이미지를 요청하게 되요.

- 기존 데이터를 어떻게 활용할 것일까?
	- 기존 데이터는 그냥 쌩 인터넷에 올라와 있는 url 이에요
		- 이 때 S3 에 올라가 있는 사진을 지우려고 한다고 가정해볼게요.
			- 그러면 어떤 것은 실제로 S3 에서 지울 수 있는 사진이고
			- 어떤 것은 인터넷에 올라와 있는 사진이니 지울 수 없을거에요.
			- 이 부분은 딱히 문제가 되지 않을까요??
			- 그냥 DB 에서만 지우면 되니까 전혀 문제가 되지 않을까요?
	- ec2 에 작은 Spring Boot Project 를 하나 띄워서 현재 DB 상에 있는 image url 을 모두 파일로 저장하고, S3 에 올리는 방법도 있을 것 같아요 (기존 데이터를 S3 에 이관하기 위해서)

- 이미지 삭제.. 전에 많이 이야기 나눴지만 막상 S3 와 함께 구현해보려 하니까 쉽지 않아요
	- 현재는 핀을 복사하는 기능이 존재해요
	- 그렇기 때문에 Image URL 과 같은 정보는 그대로 복사가 되죠.
	- 여기서 발생하는 문제는 실제로 S3 의 이미지를 지울 때 발생해요.
	- 어떤 한 유저가 Image 지울 때 같이 S3 의 이미지도 지우면 동일한 Image URL 을 가지고 있던 핀들은 모두 이미지를 조회할 수 없게 되요.
	- 간단하게 이 문제를 해결할 방법을 생각해봤는데, PinImage Entity 에서 imageURL 을 unique 하게 만들어, 동일한 URL 이라면 하나로 묶어주는거에요.
	- 위 방법을 채택하게 되면 이미지를 추가할 때의 로직이 현재와 조금 달라지겠지만, 어떤 User 가 해당 image 를 삭제했을 때, 이제 이 image url 이 DB 상에 하나도 존재하지 않는지 확인하고 S3 에서 제거할 수 있어요.
	- 근데 여기서 문제가 발생하는데, 근데 또 기본 이미지는 어떻게 하죠? 허허허허... 미치겠네요

- 아직 Rest Docs 를 해결하지 못했더연 도이 말씀대로 notion 에다가 일단 명세 남겨놓고 해결해나가겠습니다. 똥송해연..

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

closed #386

<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->

https://blog.pium.life/aws-s3-apply/
