### PR TITLE
[FE] Fix/permission 토픽 권한 수정 오류 해결

### DIFF
--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -3,6 +3,6 @@ import { defineConfig } from 'cypress';
 export default defineConfig({
   e2e: {
     baseUrl: 'http://localhost:3000',
-    defaultCommandTimeout: 10000,
+    defaultCommandTimeout: 20000,
   },
 });

--- a/frontend/cypress/e2e/mapbefine.cy.ts
+++ b/frontend/cypress/e2e/mapbefine.cy.ts
@@ -69,7 +69,7 @@ describe('토픽 상세 페이지', () => {
         if (index === 0) $el.click();
       });
 
-    cy.wait(3000);
+    cy.wait(5000);
 
     cy.get('span').each(($el, index) => {
       if (index === 6) $el.click();
@@ -87,7 +87,7 @@ describe('토픽 상세 페이지', () => {
         if (index === 0) $el.click();
       });
 
-    cy.wait(2000);
+    cy.wait(5000);
 
     cy.get('span').each(($el, index) => {
       if (index === 6) $el.click();

--- a/frontend/src/components/AuthorityRadioContainer/index.tsx
+++ b/frontend/src/components/AuthorityRadioContainer/index.tsx
@@ -16,7 +16,7 @@ import useGet from '../../apiHooks/useGet';
 
 interface AuthorityRadioContainer {
   isPrivate: boolean;
-  isAll: boolean;
+  isPublic: boolean;
   authorizedMemberIds: number[];
   setIsPrivate: React.Dispatch<React.SetStateAction<boolean>>;
   setIsAll: React.Dispatch<React.SetStateAction<boolean>>;
@@ -26,7 +26,7 @@ interface AuthorityRadioContainer {
 
 const AuthorityRadioContainer = ({
   isPrivate,
-  isAll,
+  isPublic,
   authorizedMemberIds,
   setIsPrivate,
   setIsAll,
@@ -37,6 +37,8 @@ const AuthorityRadioContainer = ({
   const { fetchGet } = useGet();
 
   const [members, setMembers] = useState<TopicAuthorMember[]>([]);
+  const viewPrevAuthorMembersCondition =
+    authorizedMemberIds.length === 0 && !isPublic;
 
   useEffect(() => {
     fetchGet<TopicAuthorMember[]>(
@@ -63,10 +65,6 @@ const AuthorityRadioContainer = ({
     setAuthorizedMemberIds((prev: TopicAuthorMember['id'][]) =>
       isChecked ? [...prev, id] : prev.filter((n: number) => n !== id),
     );
-  };
-
-  const whenViewingPreviousAuthorMember = () => {
-    return authorizedMemberIds.length === 0 && !isAll;
   };
 
   return (
@@ -115,7 +113,7 @@ const AuthorityRadioContainer = ({
           <input
             type="radio"
             id="permission-all"
-            checked={isAll}
+            checked={isPublic}
             onChange={onChangeInitAuthMembersWithSetIsAll}
             tabIndex={5}
           />
@@ -132,10 +130,10 @@ const AuthorityRadioContainer = ({
         <input
           type="radio"
           id="permission-group"
-          checked={!isAll}
+          checked={!isPublic}
           onChange={onChangeInitAuthMembers}
           onClick={() => {
-            isAll === false && openModal('newTopic');
+            isPublic === false && openModal('newTopic');
           }}
           tabIndex={5}
         />
@@ -169,7 +167,7 @@ const AuthorityRadioContainer = ({
         </>
       )}
 
-      {permissionedMembers && whenViewingPreviousAuthorMember() && (
+      {permissionedMembers && viewPrevAuthorMembersCondition && (
         <>
           <Space size={5} />
           <Space size={0} />

--- a/frontend/src/components/AuthorityRadioContainer/index.tsx
+++ b/frontend/src/components/AuthorityRadioContainer/index.tsx
@@ -175,19 +175,25 @@ const AuthorityRadioContainer = ({
           <Space size={0} />
           <Box>
             <Text color="black" $fontSize="default" $fontWeight="normal">
-              기존에 선택한 친구들
+              이전에 권한을 부여한 친구들
             </Text>
             <Space size={1} />
-            {permissionedMembers.map((member) => (
-              <Text
-                color="black"
-                $fontSize="default"
-                $fontWeight="normal"
-                key={member.id}
-              >
-                • {member.memberResponse.nickName}
+            {permissionedMembers.length > 0 ? (
+              permissionedMembers.map((member) => (
+                <Text
+                  color="black"
+                  $fontSize="default"
+                  $fontWeight="normal"
+                  key={member.id}
+                >
+                  • {member.memberResponse.nickName}
+                </Text>
+              ))
+            ) : (
+              <Text color="black" $fontSize="default" $fontWeight="normal">
+                • 없음
               </Text>
-            ))}
+            )}
           </Box>
         </>
       )}

--- a/frontend/src/components/AuthorityRadioContainer/index.tsx
+++ b/frontend/src/components/AuthorityRadioContainer/index.tsx
@@ -3,7 +3,10 @@ import Text from '../common/Text';
 import Space from '../common/Space';
 import Flex from '../common/Flex';
 import { useContext, useEffect, useState } from 'react';
-import { TopicAuthorMember, TopicAuthorMemberWithId } from '../../types/Topic';
+import {
+  TopicAuthorMember,
+  TopicAuthorMemberWithAuthorId,
+} from '../../types/Topic';
 import { ModalContext } from '../../context/ModalContext';
 import Box from '../common/Box';
 import Modal from '../Modal';
@@ -18,7 +21,7 @@ interface AuthorityRadioContainer {
   setIsPrivate: React.Dispatch<React.SetStateAction<boolean>>;
   setIsAll: React.Dispatch<React.SetStateAction<boolean>>;
   setAuthorizedMemberIds: React.Dispatch<React.SetStateAction<number[]>>;
-  permissionedMembers?: TopicAuthorMemberWithId[];
+  permissionedMembers?: TopicAuthorMemberWithAuthorId[];
 }
 
 const AuthorityRadioContainer = ({
@@ -60,6 +63,10 @@ const AuthorityRadioContainer = ({
     setAuthorizedMemberIds((prev: TopicAuthorMember['id'][]) =>
       isChecked ? [...prev, id] : prev.filter((n: number) => n !== id),
     );
+  };
+
+  const whenViewingPreviousAuthorMember = () => {
+    return authorizedMemberIds.length === 0 && !isAll;
   };
 
   return (
@@ -162,7 +169,7 @@ const AuthorityRadioContainer = ({
         </>
       )}
 
-      {authorizedMemberIds.length === 0 && permissionedMembers && (
+      {permissionedMembers && whenViewingPreviousAuthorMember() && (
         <>
           <Space size={5} />
           <Space size={0} />

--- a/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
+++ b/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
@@ -47,7 +47,7 @@ const UpdatedTopicInfo = ({
   const [topicAuthorInfo, setTopicAuthorInfo] =
     useState<TopicAuthorInfo | null>(null);
   const [isPrivate, setIsPrivate] = useState(false); // 혼자 볼 지도 :  같이 볼 지도
-  const [isAll, setIsAll] = useState(true); // 모두 : 지정 인원
+  const [isPublic, setIsPublic] = useState(true); // 모두 : 지정 인원
   const [authorizedMemberIds, setAuthorizedMemberIds] = useState<number[]>([]);
 
   const updateTopicInfo = async () => {
@@ -59,7 +59,7 @@ const UpdatedTopicInfo = ({
           image,
           description: formValues.description,
           publicity: isPrivate ? 'PRIVATE' : 'PUBLIC',
-          permissionType: isAll && !isPrivate ? 'ALL_MEMBERS' : 'GROUP_ONLY',
+          permissionType: isPublic && !isPrivate ? 'ALL_MEMBERS' : 'GROUP_ONLY',
         },
         errorMessage: `권한은 '공개 ➡️ 비공개', '모두 ➡️ 친구', '친구 ➡️ 혼자' 로 변경할 수 없습니다.`,
         isThrow: true,
@@ -103,7 +103,7 @@ const UpdatedTopicInfo = ({
         setTopicAuthorInfo(response);
         setIsPrivate(response.publicity === 'PRIVATE');
 
-        setIsAll(response.permissionedMembers.length === 0);
+        setIsPublic(response.permissionedMembers.length === 0);
       },
     );
   }, []);
@@ -140,10 +140,10 @@ const UpdatedTopicInfo = ({
 
       <AuthorityRadioContainer
         isPrivate={isPrivate}
-        isAll={isAll}
+        isPublic={isPublic}
         authorizedMemberIds={authorizedMemberIds}
         setIsPrivate={setIsPrivate}
-        setIsAll={setIsAll}
+        setIsAll={setIsPublic}
         setAuthorizedMemberIds={setAuthorizedMemberIds}
         permissionedMembers={topicAuthorInfo?.permissionedMembers}
       />

--- a/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
+++ b/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
@@ -61,7 +61,7 @@ const UpdatedTopicInfo = ({
           publicity: isPrivate ? 'PRIVATE' : 'PUBLIC',
           permissionType: isAll && !isPrivate ? 'ALL_MEMBERS' : 'GROUP_ONLY',
         },
-        errorMessage: `권한은 '공개 ➡️ 비공개', '모두 ➡️ 친구들', '친구들 ➡️ 혼자' 로 변경할 수 없습니다.`,
+        errorMessage: `권한은 '공개 ➡️ 비공개', '모두 ➡️ 친구', '친구 ➡️ 혼자' 로 변경할 수 없습니다.`,
         isThrow: true,
       });
 
@@ -75,7 +75,7 @@ const UpdatedTopicInfo = ({
   const updateTopicAuthority = async () => {
     // topicAuthorInfo api 구조 이상으로 권한 설정 자체에 대한 id를 사용 (topicId 아님)
     await fetchDelete({
-      url: `/permissions/${topicAuthorInfo?.permissionMembers[0].id}`,
+      url: `/permissions/${topicAuthorInfo?.permissionedMembers[0].id}`,
       errorMessage: '권한 삭제에 실패했습니다.',
       isThrow: true,
     });
@@ -103,9 +103,7 @@ const UpdatedTopicInfo = ({
         setTopicAuthorInfo(response);
         setIsPrivate(response.publicity === 'PRIVATE');
 
-        if (topicAuthorInfo) {
-          setIsAll(topicAuthorInfo?.permissionMembers.length === 0);
-        }
+        setIsAll(response.permissionedMembers.length === 0);
       },
     );
   }, []);
@@ -147,7 +145,7 @@ const UpdatedTopicInfo = ({
         setIsPrivate={setIsPrivate}
         setIsAll={setIsAll}
         setAuthorizedMemberIds={setAuthorizedMemberIds}
-        permissionedMembers={topicAuthorInfo?.permissionMembers}
+        permissionedMembers={topicAuthorInfo?.permissionedMembers}
       />
 
       <Space size={6} />

--- a/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
+++ b/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
@@ -61,7 +61,7 @@ const UpdatedTopicInfo = ({
           publicity: isPrivate ? 'PRIVATE' : 'PUBLIC',
           permissionType: isAll && !isPrivate ? 'ALL_MEMBERS' : 'GROUP_ONLY',
         },
-        errorMessage: `'공개 ➡️ 비공개', '모두 ➡️ 친구들', '친구들 ➡️ 혼자' 로 변경할 수 없습니다.`,
+        errorMessage: `권한은 '공개 ➡️ 비공개', '모두 ➡️ 친구들', '친구들 ➡️ 혼자' 로 변경할 수 없습니다.`,
         isThrow: true,
       });
 

--- a/frontend/src/pages/NewTopic.tsx
+++ b/frontend/src/pages/NewTopic.tsx
@@ -35,7 +35,7 @@ const NewTopic = () => {
     });
 
   const [isPrivate, setIsPrivate] = useState(false); // 혼자 볼 지도 :  같이 볼 지도
-  const [isAll, setIsAll] = useState(true); // 모두 : 지정 인원
+  const [isPublic, setIsPublic] = useState(true); // 모두 : 지정 인원
   const [authorizedMemberIds, setAuthorizedMemberIds] = useState<number[]>([]);
 
   const goToBack = () => {
@@ -77,7 +77,7 @@ const NewTopic = () => {
         description: formValues.description,
         pins: pulledPinIds ? pulledPinIds.split(',') : [],
         publicity: isPrivate ? 'PRIVATE' : 'PUBLIC',
-        permissionType: isAll && !isPrivate ? 'ALL_MEMBERS' : 'GROUP_ONLY',
+        permissionType: isPublic && !isPrivate ? 'ALL_MEMBERS' : 'GROUP_ONLY',
       },
       errorMessage:
         '지도 생성에 실패하였습니다. 입력하신 항목들을 다시 확인해주세요.',
@@ -88,7 +88,7 @@ const NewTopic = () => {
   };
 
   const addAuthorityToTopicWithGroupPermission = async (topicId: number) => {
-    if (isAll) return;
+    if (isPublic) return;
 
     fetchPost({
       url: '/permissions',
@@ -161,10 +161,10 @@ const NewTopic = () => {
 
         <AuthorityRadioContainer
           isPrivate={isPrivate}
-          isAll={isAll}
+          isPublic={isPublic}
           authorizedMemberIds={authorizedMemberIds}
           setIsPrivate={setIsPrivate}
-          setIsAll={setIsAll}
+          setIsAll={setIsPublic}
           setAuthorizedMemberIds={setAuthorizedMemberIds}
         />
 

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -126,7 +126,7 @@ const SelectedTopic = () => {
         {topicDetails.map((topicDetail, idx) => (
           <Fragment key={topicDetail.id}>
             <PinsOfTopic
-              topicId={topicId}
+              topicId={topicId.split(',')[idx]}
               idx={idx}
               topicDetail={topicDetail}
               setSelectedPinId={setSelectedPinId}

--- a/frontend/src/types/Topic.ts
+++ b/frontend/src/types/Topic.ts
@@ -40,10 +40,10 @@ export interface ModalTopicCardProps {
 
 export interface TopicAuthorInfo {
   publicity: 'PUBLIC' | 'PRIVATE';
-  permissionMembers: TopicAuthorMemberWithId[];
+  permissionedMembers: TopicAuthorMemberWithAuthorId[];
 }
 
-export interface TopicAuthorMemberWithId {
+export interface TopicAuthorMemberWithAuthorId {
   id: number;
   memberResponse: TopicAuthorMember;
 }


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
토픽 수정에 대하여 다음과 오류를 수정한다.
* 모아보기 상태에서 토픽 수정을 하지 못한 오류
* 토픽 수정 시 토픽을 생성할 때 설정한 권한을 불러와 UI를 업데이트 하지 못하던 오류
* '기존에 선택한 인원' 들을 조건적으로 표시하지 못하던 오류 수정

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] 모아보기 상태에서 토픽 수정을 하지 못한 오류 수정
- [x] 토픽 수정 시 토픽을 생성할 때 설정한 권한을 불러와 UI를 업데이트 하지 못하던 오류 수정
- [x] '기존에 선택한 인원' 들을 조건적으로 표시하지 못하던 오류 수정

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
이미지를 추가할 수 없어 토픽 추가 및 수정이 안 되는 상황이기에, 실제 API 통신은 GET 만 진행하였습니다. 예기치 못한 오류가 있을 수도 있습니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
