### PR TITLE
[ FE ] Refactor/#404 홈페이지 및 Navbar 리팩토링

### DIFF
--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -25,14 +25,14 @@ interface NavBarProps {
   $layoutWidth: '100vw' | '372px';
 }
 
-type NavbarItem = {
+interface NavbarItemProps {
   key: NavbarHighlightKeys;
   label: string;
   icon: React.FunctionComponent;
   focusIcon: React.FunctionComponent;
-};
+}
 
-const NAV_ITEMS: NavbarItem[] = [
+const NAV_ITEMS: NavbarItemProps[] = [
   { key: 'home', label: '홈', icon: Home, focusIcon: FocusHome },
   {
     key: 'seeTogether',

--- a/frontend/src/components/Layout/Navbar.tsx
+++ b/frontend/src/components/Layout/Navbar.tsx
@@ -4,7 +4,6 @@ import useNavigator from '../../hooks/useNavigator';
 import Flex from '../common/Flex';
 import Button from '../common/Button';
 import Space from '../common/Space';
-import Text from '../common/Text';
 import Home from '../../assets/nav_home.svg';
 import SeeTogether from '../../assets/nav_seeTogether.svg';
 import Favorite from '../../assets/nav_favorite.svg';
@@ -16,152 +15,72 @@ import FocusFavorite from '../../assets/nav_favorite_focus.svg';
 import FocusAddMapOrPin from '../../assets/nav_addMapOrPin_focus.svg';
 import FocusProfile from '../../assets/nav_profile_focus.svg';
 import Modal from '../Modal';
-import { ModalContext } from '../../context/ModalContext';
-import { NavbarHighlightsContext } from '../../context/NavbarHighlightsContext';
-import { useParams } from 'react-router-dom';
-import SeeTogetherCounter from '../SeeTogetherCounter';
-import useKeyDown from '../../hooks/useKeyDown';
+import {
+  NavbarHighlightKeys,
+  NavbarHighlightsContext,
+} from '../../context/NavbarHighlightsContext';
+import NavbarItem from './NavbarItem';
 
 interface NavBarProps {
   $layoutWidth: '100vw' | '372px';
 }
 
+type NavbarItem = {
+  key: NavbarHighlightKeys;
+  label: string;
+  icon: React.FunctionComponent;
+  focusIcon: React.FunctionComponent;
+};
+
+const NAV_ITEMS: NavbarItem[] = [
+  { key: 'home', label: '홈', icon: Home, focusIcon: FocusHome },
+  {
+    key: 'seeTogether',
+    label: '모아보기',
+    icon: SeeTogether,
+    focusIcon: FocusSeeTogether,
+  },
+  {
+    key: 'addMapOrPin',
+    label: '추가하기',
+    icon: AddMapOrPin,
+    focusIcon: FocusAddMapOrPin,
+  },
+  {
+    key: 'favorite',
+    label: '즐겨찾기',
+    icon: Favorite,
+    focusIcon: FocusFavorite,
+  },
+  {
+    key: 'profile',
+    label: '내 정보',
+    icon: Profile,
+    focusIcon: FocusProfile,
+  },
+];
+
 const Navbar = ({ $layoutWidth }: NavBarProps) => {
-  const { routePage } = useNavigator();
-  const { topicId } = useParams();
-  const { openModal, closeModal } = useContext(ModalContext);
+  const { routingHandlers } = useNavigator();
   const { navbarHighlights } = useContext(NavbarHighlightsContext);
-  const { elementRef: firstElement, onElementKeyDown: firstKeyDown } =
-    useKeyDown<HTMLDivElement>();
-  const { elementRef: secondElement, onElementKeyDown: secondKeyDown } =
-    useKeyDown<HTMLDivElement>();
-  const { elementRef: thirdElement, onElementKeyDown: thirdKeyDown } =
-    useKeyDown<HTMLDivElement>();
-  const { elementRef: fourElement, onElementKeyDown: fourKeyDown } =
-    useKeyDown<HTMLDivElement>();
-  const { elementRef: FifthElement, onElementKeyDown: FifthKeyDown } =
-    useKeyDown<HTMLDivElement>();
-
-  const goToHome = () => {
-    routePage('/');
-  };
-
-  const goToSeeTogether = () => {
-    routePage('/see-together');
-  };
-
-  const onClickAddMapOrPin = () => {
-    openModal('addMapOrPin');
-  };
-
-  const goToFavorite = () => {
-    routePage('/favorite');
-  };
-
-  const goToProfile = () => {
-    routePage('/my-page');
-  };
-
-  const goToNewTopic = () => {
-    routePage('/new-topic');
-    closeModal('addMapOrPin');
-  };
-
-  const goToNewPin = () => {
-    routePage('/new-pin', topicId);
-    closeModal('addMapOrPin');
-  };
-
   return (
     <Wrapper
       $isAddPage={navbarHighlights.addMapOrPin}
       $layoutWidth={$layoutWidth}
     >
-      <IconWrapper
-        $layoutWidth={$layoutWidth}
-        onClick={goToHome}
-        tabIndex={10}
-        ref={firstElement}
-        onKeyDown={firstKeyDown}
-      >
-        {navbarHighlights.home ? <FocusHome /> : <Home />}
-        <Text
-          color={navbarHighlights.home ? 'primary' : 'darkGray'}
-          $fontSize="extraSmall"
-          $fontWeight="normal"
-        >
-          홈
-        </Text>
-      </IconWrapper>
-
-      <IconWrapper
-        $layoutWidth={$layoutWidth}
-        onClick={goToSeeTogether}
-        tabIndex={10}
-        ref={secondElement}
-        onKeyDown={secondKeyDown}
-      >
-        {navbarHighlights.seeTogether ? <FocusSeeTogether /> : <SeeTogether />}
-        <Text
-          color={navbarHighlights.seeTogether ? 'primary' : 'darkGray'}
-          $fontSize="extraSmall"
-          $fontWeight="normal"
-        >
-          모아보기
-        </Text>
-        <SeeTogetherCounter />
-      </IconWrapper>
-
-      <IconWrapper
-        $layoutWidth={$layoutWidth}
-        onClick={onClickAddMapOrPin}
-        tabIndex={10}
-        ref={thirdElement}
-        onKeyDown={thirdKeyDown}
-      >
-        {navbarHighlights.addMapOrPin ? <FocusAddMapOrPin /> : <AddMapOrPin />}
-        <Text
-          color={navbarHighlights.addMapOrPin ? 'primary' : 'darkGray'}
-          $fontSize="extraSmall"
-          $fontWeight="normal"
-        >
-          추가하기
-        </Text>
-      </IconWrapper>
-
-      <IconWrapper
-        $layoutWidth={$layoutWidth}
-        onClick={goToFavorite}
-        tabIndex={11}
-        ref={fourElement}
-        onKeyDown={fourKeyDown}
-      >
-        {navbarHighlights.favorite ? <FocusFavorite /> : <Favorite />}
-        <Text
-          color={navbarHighlights.favorite ? 'primary' : 'darkGray'}
-          $fontSize="extraSmall"
-          $fontWeight="normal"
-        >
-          즐겨찾기
-        </Text>
-      </IconWrapper>
-
-      <IconWrapper
-        $layoutWidth={$layoutWidth}
-        onClick={goToProfile}
-        tabIndex={11}
-        ref={FifthElement}
-        onKeyDown={FifthKeyDown}
-      >
-        {navbarHighlights.profile ? <FocusProfile /> : <Profile />}
-        <Text
-          color={navbarHighlights.profile ? 'primary' : 'darkGray'}
-          $fontSize="extraSmall"
-          $fontWeight="normal"
-        >
-          내 정보
-        </Text>
-      </IconWrapper>
+      {NAV_ITEMS.map((item) => {
+        return (
+          <NavbarItem
+            key={item.key}
+            label={item.label}
+            icon={item.icon}
+            focusIcon={item.focusIcon}
+            isHighlighted={navbarHighlights[item.key]}
+            onClick={() => routingHandlers[item.key]()}
+            $layoutWidth={$layoutWidth}
+          />
+        );
+      })}
 
       <Modal
         modalKey="addMapOrPin"
@@ -173,11 +92,19 @@ const Navbar = ({ $layoutWidth }: NavBarProps) => {
         left={$layoutWidth === '100vw' ? '' : `${372 / 2}px`}
       >
         <Flex $justifyContent="center" width="100%">
-          <RouteButton variant="primary" onClick={goToNewTopic} tabIndex={10}>
+          <RouteButton
+            variant="primary"
+            onClick={routingHandlers['newTopic']}
+            tabIndex={10}
+          >
             지도 추가하기
           </RouteButton>
           <Space size={4} />
-          <RouteButton variant="primary" onClick={goToNewPin} tabIndex={10}>
+          <RouteButton
+            variant="primary"
+            onClick={routingHandlers['newPin']}
+            tabIndex={10}
+          >
             핀 추가하기
           </RouteButton>
         </Flex>
@@ -209,25 +136,6 @@ const Wrapper = styled.nav<{
         position: fixed;
         bottom: 0;
       `}
-  }
-`;
-
-const IconWrapper = styled.div<{ $layoutWidth: '100vw' | '372px' }>`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 52px;
-  cursor: pointer;
-  margin-right: ${({ $layoutWidth }) =>
-    $layoutWidth === '100vw' ? '48px' : '0'};
-
-  &:last-of-type {
-    margin-right: 0;
-  }
-
-  @media (max-width: 1076px) {
-    margin-right: 0;
   }
 `;
 

--- a/frontend/src/components/Layout/NavbarItem.tsx
+++ b/frontend/src/components/Layout/NavbarItem.tsx
@@ -1,12 +1,12 @@
-import { ReactElement } from 'react';
+import { FunctionComponent } from 'react';
 import styled from 'styled-components';
 import useKeyDown from '../../hooks/useKeyDown';
 import Text from '../common/Text';
 
 interface NavbarItemProps {
   label: string;
-  icon: ReactElement;
-  focusIcon: ReactElement;
+  icon: FunctionComponent;
+  focusIcon: FunctionComponent;
   isHighlighted?: boolean;
   onClick: () => void;
   $layoutWidth: '100vw' | '372px';
@@ -30,7 +30,7 @@ const NavbarItem = ({
       onKeyDown={onElementKeyDown}
       $layoutWidth={$layoutWidth}
     >
-      {isHighlighted ? FocusIcon : Icon}
+      {isHighlighted ? <FocusIcon /> : <Icon />}
       <Text
         color={isHighlighted ? 'primary' : 'darkGray'}
         $fontSize="extraSmall"

--- a/frontend/src/components/Layout/NavbarItem.tsx
+++ b/frontend/src/components/Layout/NavbarItem.tsx
@@ -1,0 +1,64 @@
+import { ReactElement } from 'react';
+import styled from 'styled-components';
+import useKeyDown from '../../hooks/useKeyDown';
+import Text from '../common/Text';
+
+interface NavbarItemProps {
+  label: string;
+  icon: ReactElement;
+  focusIcon: ReactElement;
+  isHighlighted?: boolean;
+  onClick: () => void;
+  $layoutWidth: '100vw' | '372px';
+}
+
+const NavbarItem = ({
+  label,
+  icon: Icon,
+  focusIcon: FocusIcon,
+  isHighlighted = false,
+  onClick,
+  $layoutWidth,
+}: NavbarItemProps) => {
+  const { elementRef, onElementKeyDown } = useKeyDown<HTMLDivElement>();
+
+  return (
+    <IconWrapper
+      onClick={onClick}
+      tabIndex={10}
+      ref={elementRef}
+      onKeyDown={onElementKeyDown}
+      $layoutWidth={$layoutWidth}
+    >
+      {isHighlighted ? FocusIcon : Icon}
+      <Text
+        color={isHighlighted ? 'primary' : 'darkGray'}
+        $fontSize="extraSmall"
+        $fontWeight="normal"
+      >
+        {label}
+      </Text>
+    </IconWrapper>
+  );
+};
+
+const IconWrapper = styled.div<{ $layoutWidth: '100vw' | '372px' }>`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 52px;
+  cursor: pointer;
+  margin-right: ${({ $layoutWidth }) =>
+    $layoutWidth === '100vw' ? '48px' : '0'};
+
+  &:last-of-type {
+    margin-right: 0;
+  }
+
+  @media (max-width: 1076px) {
+    margin-right: 0;
+  }
+`;
+
+export default NavbarItem;

--- a/frontend/src/hooks/useNavigator.ts
+++ b/frontend/src/hooks/useNavigator.ts
@@ -1,14 +1,33 @@
-import { useNavigate } from 'react-router-dom';
+import { useContext } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ModalContext } from '../context/ModalContext';
 
 const useNavigator = () => {
   const navigator = useNavigate();
+
+  const { openModal, closeModal } = useContext(ModalContext);
+  const { topicId } = useParams();
 
   const routePage = (url: string | -1, value?: string | number | number[]) => {
     if (typeof url === 'string') navigator(url, { state: value });
     if (url === -1) navigator(url);
   };
 
-  return { routePage };
+  return {
+    home: () => routePage('/'),
+    seeTogether: () => routePage('/see-together'),
+    addMapOrPin: () => openModal('addMapOrPin'),
+    favorite: () => routePage('/favorite'),
+    profile: () => routePage('/my-page'),
+    newTopic: () => {
+      routePage('/new-topic');
+      closeModal('addMapOrPin');
+    },
+    newPin: () => {
+      routePage(`/new-pin/${topicId}`);
+      closeModal('addMapOrPin');
+    },
+  };
 };
 
 export default useNavigator;

--- a/frontend/src/hooks/useNavigator.ts
+++ b/frontend/src/hooks/useNavigator.ts
@@ -7,7 +7,6 @@ const useNavigator = () => {
 
   const { openModal, closeModal } = useContext(ModalContext);
   const { topicId } = useParams();
-
   const routePage = (url: string | -1, value?: string | number | number[]) => {
     if (typeof url === 'string') navigator(url, { state: value });
     if (url === -1) navigator(url);
@@ -25,9 +24,12 @@ const useNavigator = () => {
         closeModal('addMapOrPin');
       },
       newPin: () => {
-        routePage(`/new-pin/${topicId}`);
+        routePage('/new-pin', topicId);
         closeModal('addMapOrPin');
       },
+      goToPopularTopics: () => routePage('see-all/popularity'),
+      goToNearByMeTopics: () => routePage('see-all/near'),
+      goToLatestTopics: () => routePage('see-all/latest'),
     },
     routePage,
   };

--- a/frontend/src/hooks/useNavigator.ts
+++ b/frontend/src/hooks/useNavigator.ts
@@ -29,6 +29,7 @@ const useNavigator = () => {
         closeModal('addMapOrPin');
       },
     },
+    routePage,
   };
 };
 

--- a/frontend/src/hooks/useNavigator.ts
+++ b/frontend/src/hooks/useNavigator.ts
@@ -14,18 +14,20 @@ const useNavigator = () => {
   };
 
   return {
-    home: () => routePage('/'),
-    seeTogether: () => routePage('/see-together'),
-    addMapOrPin: () => openModal('addMapOrPin'),
-    favorite: () => routePage('/favorite'),
-    profile: () => routePage('/my-page'),
-    newTopic: () => {
-      routePage('/new-topic');
-      closeModal('addMapOrPin');
-    },
-    newPin: () => {
-      routePage(`/new-pin/${topicId}`);
-      closeModal('addMapOrPin');
+    routingHandlers: {
+      home: () => routePage('/'),
+      seeTogether: () => routePage('/see-together'),
+      addMapOrPin: () => openModal('addMapOrPin'),
+      favorite: () => routePage('/favorite'),
+      profile: () => routePage('/my-page'),
+      newTopic: () => {
+        routePage('/new-topic');
+        closeModal('addMapOrPin');
+      },
+      newPin: () => {
+        routePage(`/new-pin/${topicId}`);
+        closeModal('addMapOrPin');
+      },
     },
   };
 };

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,4 @@
 import Space from '../components/common/Space';
-import Box from '../components/common/Box';
 import useNavigator from '../hooks/useNavigator';
 import { css, styled } from 'styled-components';
 import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
@@ -15,23 +14,15 @@ const TopicListContainer = lazy(
 );
 
 const Home = () => {
-  const { routePage } = useNavigator();
+  const { routingHandlers } = useNavigator();
+  const { goToPopularTopics, goToLatestTopics, goToNearByMeTopics } =
+    routingHandlers;
+
   const { markers, removeMarkers, removeInfowindows } =
     useContext(MarkerContext);
+
   useSetLayoutWidth(FULLSCREEN);
   useSetNavbarHighlight('home');
-
-  const goToPopularTopics = () => {
-    routePage('see-all/popularity');
-  };
-
-  const goToNearByMeTopics = () => {
-    routePage('see-all/near');
-  };
-
-  const goToLatestTopics = () => {
-    routePage('see-all/latest');
-  };
 
   useEffect(() => {
     if (markers && markers.length > 0) {


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
홈페이지 및 Navbar 중복로직 제거 및 컴포넌트 분리
## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- Navbar의 반복되는 로직을 제거한다
- Navbar의 각 항목( 홈, 즐겨찾기 등)을 NavbarItem 컴포넌트로 분리한다
- 페이지 이동 로직 및 keyDown 이벤트를 분리한다
## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
-  기존에 있던 useNavigator에 각 컴포넌트에 흩어져있던 페이지 이동 로직을 모아뒀습니다. 
홈과 Navbar이외에 컴포넌트에는 아직 변경된 사항을 적용 안했습니다
## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
#404 
<!-- closed #번호 --> 
closed #404 
## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
