### PR TITLE
[BE] Refactor/#400 토픽 조회 시 업데이트 일시를 최근에 핀이 추가/변경된 일시로 변경

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/common/entity/BaseTimeEntity.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/common/entity/BaseTimeEntity.java
@@ -2,6 +2,7 @@ package com.mapbefine.mapbefine.common.entity;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -18,6 +19,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public abstract class BaseTimeEntity {
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
@@ -17,6 +17,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -84,6 +86,16 @@ public class Pin extends BaseTimeEntity {
         creator.addPin(pin);
 
         return pin;
+    }
+
+    @PrePersist
+    protected void prePersist() {
+        topic.updateLastPinUpdatedAt(getUpdatedAt());
+    }
+
+    @PreUpdate
+    protected void preUpdate() {
+        topic.updateLastPinUpdatedAt(getUpdatedAt());
     }
 
     public void updatePinInfo(String name, String description) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
@@ -26,5 +26,4 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
 
     List<Pin> findAllByCreatorId(Long creatorId);
 
-    List<Pin> findAllByOrderByUpdatedAtDesc();
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
@@ -8,8 +8,6 @@ import com.mapbefine.mapbefine.auth.domain.AuthMember;
 import com.mapbefine.mapbefine.bookmark.domain.Bookmark;
 import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
-import com.mapbefine.mapbefine.pin.domain.Pin;
-import com.mapbefine.mapbefine.pin.domain.PinRepository;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
@@ -28,16 +26,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class TopicQueryService {
 
     private final TopicRepository topicRepository;
-    private final PinRepository pinRepository;
     private final MemberRepository memberRepository;
 
     public TopicQueryService(
             TopicRepository topicRepository,
-            PinRepository pinRepository,
             MemberRepository memberRepository
     ) {
         this.topicRepository = topicRepository;
-        this.pinRepository = pinRepository;
         this.memberRepository = memberRepository;
     }
 
@@ -223,10 +218,8 @@ public class TopicQueryService {
         List<Topic> topicsInAtlas = findTopicsInAtlas(member);
         List<Topic> topicsInBookMark = findBookMarkedTopics(member);
 
-        return pinRepository.findAllByOrderByUpdatedAtDesc()
+        return topicRepository.findAllByOrderByLastPinUpdatedAtDesc()
                 .stream()
-                .map(Pin::getTopic)
-                .distinct()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
                         topic,
@@ -237,10 +230,8 @@ public class TopicQueryService {
     }
 
     private List<TopicResponse> getGuestNewestTopicResponse(AuthMember authMember) {
-        return pinRepository.findAllByOrderByUpdatedAtDesc()
+        return topicRepository.findAllByOrderByLastPinUpdatedAtDesc()
                 .stream()
-                .map(Pin::getTopic)
-                .distinct()
                 .filter(authMember::canRead)
                 .map(TopicResponse::fromGuestQuery)
                 .toList();

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
@@ -17,6 +17,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.PrePersist;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -55,6 +57,9 @@ public class Topic extends BaseTimeEntity {
     @ColumnDefault(value = "false")
     private boolean isDeleted = false;
 
+    @Column(nullable = false)
+    private LocalDateTime lastPinUpdatedAt;
+
     private Topic(
             TopicInfo topicInfo,
             TopicStatus topicStatus,
@@ -63,6 +68,11 @@ public class Topic extends BaseTimeEntity {
         this.topicInfo = topicInfo;
         this.topicStatus = topicStatus;
         this.creator = creator;
+    }
+
+    @PrePersist
+    protected void prePersist() {
+        lastPinUpdatedAt = LocalDateTime.now();
     }
 
     public static Topic createTopicAssociatedWithCreator(
@@ -88,6 +98,10 @@ public class Topic extends BaseTimeEntity {
             String imageUrl
     ) {
         this.topicInfo = TopicInfo.of(name, description, imageUrl);
+    }
+
+    public void updateLastPinUpdatedAt(LocalDateTime lastPinUpdatedAt) {
+        this.lastPinUpdatedAt = lastPinUpdatedAt;
     }
 
     public void updateTopicStatus(Publicity publicity, PermissionType permissionType) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
@@ -12,6 +12,12 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
 
     List<Topic> findByIdIn(List<Long> ids);
 
+    boolean existsById(Long id);
+
+    List<Topic> findAllByOrderByLastPinUpdatedAtDesc();
+
+    List<Topic> findAllByCreatorId(Long creatorId);
+
     @Modifying(clearAutomatically = true)
     @Query("update Topic t set t.isDeleted = true where t.id = :topicId")
     void deleteById(@Param("topicId") Long topicId);
@@ -19,9 +25,5 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     @Modifying(clearAutomatically = true)
     @Query("update Topic t set t.isDeleted = true where t.creator.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
-
-    boolean existsById(Long id);
-
-    List<Topic> findAllByCreatorId(Long creatorId);
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicDetailResponse.java
@@ -44,7 +44,7 @@ public record TopicDetailResponse(
                 topic.countBookmarks(),
                 isBookmarked,
                 canUpdate,
-                topic.getUpdatedAt(),
+                topic.getLastPinUpdatedAt(),
                 pinResponses
         );
     }
@@ -67,7 +67,7 @@ public record TopicDetailResponse(
                 topic.countBookmarks(),
                 Boolean.FALSE,
                 Boolean.FALSE,
-                topic.getUpdatedAt(),
+                topic.getLastPinUpdatedAt(),
                 pinResponses
         );
     }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicResponse.java
@@ -44,7 +44,7 @@ public record TopicResponse(
                 Boolean.FALSE,
                 topic.countBookmarks(),
                 Boolean.FALSE,
-                topic.getUpdatedAt()
+                topic.getLastPinUpdatedAt()
         );
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/dto/response/TopicResponse.java
@@ -28,7 +28,7 @@ public record TopicResponse(
                 isInAtlas,
                 topic.countBookmarks(),
                 isBookmarked,
-                topic.getUpdatedAt()
+                topic.getLastPinUpdatedAt()
         );
     }
 

--- a/backend/src/main/resources/data-default.sql
+++ b/backend/src/main/resources/data-default.sql
@@ -1,16 +1,16 @@
-INSERT INTO member (nick_name, email, image_url, role,
+INSERT INTO member (nick_name, email, image_url, role, status,
                     oauth_server_id, oauth_server_type,
                     created_at, updated_at)
-VALUES ('dummyMember', 'dummy@gmail.com', 'https://map-befine-official.github.io/favicon.png', 'USER',
+VALUES ('dummyMember', 'dummy@gmail.com', 'https://map-befine-official.github.io/favicon.png', 'USER', 'NORMAL',
         1L, 'KAKAO',
         now(), now());
 
-INSERT INTO topic (name, image_url, description,
+INSERT INTO topic (name, image_url, description,가
                    permission_type, publicity,
                    member_id,
-                   created_at, updated_at)
+                   created_at, updated_at, last_pin_updated_at)
 VALUES ('dummyTopic', 'https://map-befine-official.github.io/favicon.png', 'description',
         'ALL_MEMBERS', 'PUBLIC',
         1L,
-        now(), now())
+        now(), now(), now())
 ;

--- a/backend/src/test/java/com/mapbefine/mapbefine/common/annotation/ServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/common/annotation/ServiceTest.java
@@ -1,5 +1,6 @@
 package com.mapbefine.mapbefine.common.annotation;
 
+import com.mapbefine.mapbefine.common.config.JpaConfig;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -7,10 +8,12 @@ import java.lang.annotation.Target;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
 import org.springframework.stereotype.Service;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
+@Import(JpaConfig.class)
 @DataJpaTest(
         includeFilters = {
                 @Filter(type = FilterType.ANNOTATION, value = Service.class),

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
@@ -367,6 +367,8 @@ class TopicIntegrationTest extends IntegrationTest {
     @Test
     @DisplayName("핀이 추가/수정된 일자 기준 내림차순으로 토픽 목록을 조회할 경우, 200을 반환한다")
     void findAllByOrderByUpdatedAtDesc_Success() {
+        topicRepository.deleteAll();
+
         // given
         Topic topic1 = topicRepository.save(TopicFixture.createByName("topic1", member));
         Topic topic2 = topicRepository.save(TopicFixture.createByName("topic2", member));
@@ -392,6 +394,7 @@ class TopicIntegrationTest extends IntegrationTest {
                 .then().log().all()
                 .extract();
 
+        // then
         List<TopicResponse> topicResponses = response.jsonPath().getList(".", TopicResponse.class);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(topicResponses).hasSize(3);

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
@@ -135,6 +135,26 @@ class TopicQueryServiceTest {
     }
 
     @Test
+    @DisplayName("토픽 상세 조회 시 토픽의 변경일자는 핀의 최신 변경 일자이다.")
+    void findDetailById_Success_lastPinUpdatedAt() {
+        //given
+        Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
+        Location location = LocationFixture.create();
+        Pin pin = PinFixture.create(location, topic, member);
+        locationRepository.save(location);
+        topicRepository.save(topic);
+        pinRepository.save(pin);
+
+        //when
+        pin.updatePinInfo("updatePin", "updatedAt will be update");
+        pinRepository.flush();
+        TopicDetailResponse response = topicQueryService.findDetailById(new Admin(member.getId()), topic.getId());
+
+        //then
+        assertThat(response.updatedAt()).isEqualTo(pin.getUpdatedAt());
+    }
+
+    @Test
     @DisplayName("권한이 없는 토픽을 ID로 조회하면, 예외가 발생한다.")
     void findDetailById_Fail() {
         //given

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicTest.java
@@ -8,7 +8,9 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.pin.PinFixture;
 import com.mapbefine.mapbefine.pin.domain.Pin;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class TopicTest {
@@ -33,6 +35,7 @@ class TopicTest {
     }
 
     @Test
+    @DisplayName("토픽 정보를 변경한다.")
     void updateTopicInfo() {
         //given
         String name = "New Topic";
@@ -54,6 +57,7 @@ class TopicTest {
     }
 
     @Test
+    @DisplayName("토픽 상태를 변경한다.")
     void updateTopicStatus() {
         //given
         Publicity publicity = Publicity.PRIVATE;
@@ -72,6 +76,7 @@ class TopicTest {
     }
 
     @Test
+    @DisplayName("토픽의 핀 개수를 알 수 있다.")
     void countPins() {
         //given
         topic.addPin(pin);
@@ -81,15 +86,27 @@ class TopicTest {
 
         //then
         assertThat(pinCounts).isEqualTo(2);
-        // 핀이 처음 생성됐을 때, 연관관계 매핑으로 인해 하나 추가된 후 해당 메서드에서 하나 더 추가됌
     }
 
     @Test
+    @DisplayName("토픽에 직접 핀을 추가해도, 조회 전용이므로 핀 변경 일시는 반영되지 않는다.")
     void addPin() {
         //when
+        LocalDateTime beforeAdding = topic.getLastPinUpdatedAt();
         topic.addPin(pin);
 
         //then
         assertThat(topic.getPins()).contains(pin);
+        assertThat(topic.getLastPinUpdatedAt()).isEqualTo(beforeAdding);
+    }
+
+    @Test
+    @DisplayName("핀 없이 생성된 토픽의 초기 핀 추가 일시는 토픽 변경 일시와 같다.")
+    void create() {
+        // when
+        Topic emptyPinsTopic = new Topic();
+
+        //then
+        assertThat(emptyPinsTopic.getCreatedAt()).isEqualTo(emptyPinsTopic.getLastPinUpdatedAt());
     }
 }


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
- Topic, Pin : `@PrePersist`, `@PreUpdate` EntityListener 메서드 추가
- TopicQueryService : 최신순 토픽 조회 시, 기존 Pin을 모두 가져와 가공 후 정렬해야 했던 것을 lastPinUpdatedAt 컬럼으로 바로 정렬 가능하도록 바뀌었습니다.
    - TopicRepository(정렬 조회 쿼리 추가), PinRepository(정렬 조회 쿼리 삭제)
- TopicResponse, TopicDetailResponse : updatedAt 필드에 topic.getLastUpdatedAt을 넣어줍니다.
- 관련 테스트 작성

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
#400 참조.

### 사전 논의 내용
> 논의할 땐 핀이 '추가'되는 일시만 기준으로 얘기했었는데, 기존 '새로울 지도' 구현 코드를 보니 핀이 변경된 일시도 고려하고 있었더라구요. 핀이 변경된 일시도 '업데이트 일자'에 반영하는 게 자연스러운 것 같아 똑같이 진행했습니다!

토픽을 조회할 때, 토픽이 가진 핀이 추가/변경된 일시를 '업데이트 일자'로 보여주는데,  
항상 핀을 가져와 이를 조회하는 대신 ,  
토픽에 `lastPinUpdatedAt` 컬럼을 두고 핀이 추가/변경될 때 해당 컬럼을 업데이트하도록 합니다.

쓰기 작업보다 조회 작업이 더 많을 것으로 예상되어, 이 방식이 더 성능적으로 유리하다고 판단했습니다.

### 구현 방식

기존에 저희가 `createdAt`, `updatedAt`을 저장할 때에는, `AuditingEntityListner.class`에 의해 **객체를 영속화 할 때** 해당 값이 저장됩니다.
(때문에 영속화 하기 전에 객체에 `getCreatedAt`을 하면 Null 을 반환합니다.)  

그래서, 

```java
    public void addPin(Pin pin) {
        pins.add(pin);
        lastPinUpdatedAt = LocaldateTime.now(); // 영속화하는 시점이 아니라, 핀을 추가하는 코드 실행 시 시간을 저장
    }
```
**위와 같은 방식으로 구현하면 `Pin.getCreatedAt()`과 `Topic.getLastPinUpdatedAt`이 미묘하게 다른 문제가 발생합니다.**
때문에 시간을 저장하는 시점을 일관적으로 관리할 필요가 있다고 판단해 `lastPinUpdatedAt`도 **영속화 시점에 설정**되도록 하였습니다.

따라서 Pin 클래스에 아래와 같은 메서드를 추가했습니다.
```java
    @PrePersist // 엔티티를 영속화할 때(save) 메서드가 실행됩니다.
    protected void prePersist() {
        topic.updateLastPinUpdatedAt(getUpdatedAt()); // pin의 updatedAt으로 맞춰줌
    }

    @PreUpdate // flush나 commit을 호출해 데이터 베이스 업데이트를 할 때 메서드가 실행됩니다.
    protected void preUpdate() {
        topic.updateLastPinUpdatedAt(getUpdatedAt()); // pin의 updatedAt으로 맞춰줌
    }
```

이 어노테이션들은 Jpa에서 제공하는 이벤트입니다.  
BaseEntity에 쓰고 있는 `AuditingEntityListener`도 `@PrePersist`, `@PreUpdate`를 사용해 동작합니다.  
그것처럼 별로의 리스너 클래스를 분리해서 써도 되지만, 저희 로직에서는 Pin 내부에서 동작하는 게 깔끔하다고 판단했습니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
ServiceTest에서 해당 내용을 테스트하기 위해, `@ServiceTest`에 `JpaConfig.class`를 추가했습니다.
추가하지 않으면 JpaConfig 설정이 안되어있어서 JpaAuditing이  작동하지 않기때문입니당

### 배포하기 전에!!
LastPinUpdatedAt 컬럼이 새로 추가되기 때문에,  
ddl-auto : update 로 실행할 경우  
기존 레코드에 대해 새로 추가된 컬럼에 현재 시간이 추가되어 비정상적인 데이터 변경이 일어날 것으로 예상됩니다.  
따라서 배포 직후 기존 레코드에 대해 해당 컬럼에, 최신 핀 추가일시를 조회해 Update 해주는 쿼리를 작성해 직접 실행하는 게 좋을 것 같습니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
[JPA Auditing과 제대로 알아야 할 @PreUpdate](https://newwisdom.tistory.com/109)
[[JPA] 리스너 - 엔티티의 생명주기에 따른 이벤트 처리](https://ttl-blog.tistory.com/191)
