### PR TITLE
[BE] Refactor/#494 성능 개선을 위한 조회 쿼리 수정

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/atlas/domain/AtlasRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/atlas/domain/AtlasRepository.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Repository;
 public interface AtlasRepository extends JpaRepository<Atlas, Long> {
 
     boolean existsByMemberIdAndTopicId(Long memberId, Long topicId);
-
     void deleteByMemberIdAndTopicId(Long memberId, Long topicId);
 
     void deleteAllByMemberId(Long memberId);

--- a/backend/src/main/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandService.java
@@ -15,9 +15,10 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
 
 @Service
 @Transactional
@@ -84,7 +85,17 @@ public class BookmarkCommandService {
     public void deleteTopicInBookmark(AuthMember authMember, Long topicId) {
         validateBookmarkDeletingPermission(authMember, topicId);
 
-        bookmarkRepository.deleteByMemberIdAndTopicId(authMember.getMemberId(), topicId);
+        Bookmark bookmark = findBookmarkByMemberIdAndTopicId(authMember.getMemberId(), topicId);
+        Topic topic = getTopicById(topicId);
+
+        topic.removeBookmark(bookmark);
+    }
+
+    private Bookmark findBookmarkByMemberIdAndTopicId(Long memberId, Long topicId) {
+        return bookmarkRepository.findByMemberIdAndTopicId(memberId, topicId)
+                .orElseThrow(() -> new NoSuchElementException(
+                        "findBookmarkByMemberIdAndTopicId; memberId=" + memberId + " topicId=" + topicId
+                ));
     }
 
     private void validateBookmarkDeletingPermission(AuthMember authMember, Long topicId) {
@@ -95,6 +106,7 @@ public class BookmarkCommandService {
         throw new BookmarkForbiddenException(FORBIDDEN_TOPIC_DELETE);
     }
 
+    @Deprecated
     public void deleteAllBookmarks(AuthMember authMember) {
         bookmarkRepository.deleteAllByMemberId(authMember.getMemberId());
     }

--- a/backend/src/main/java/com/mapbefine/mapbefine/bookmark/domain/BookmarkRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/bookmark/domain/BookmarkRepository.java
@@ -1,12 +1,17 @@
 package com.mapbefine.mapbefine.bookmark.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByMemberIdAndTopicId(Long memberId, Long topicId);
 
+    @Modifying(clearAutomatically = true)
     void deleteAllByMemberId(Long memberId);
 
-    void deleteByMemberIdAndTopicId(Long memberId, Long topicId);
+    Optional<Bookmark> findByMemberIdAndTopicId(Long memberId, Long topicId);
+
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/location/domain/Location.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/location/domain/Location.java
@@ -10,10 +10,11 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
@@ -1,8 +1,9 @@
 package com.mapbefine.mapbefine.member.application;
 
 import com.mapbefine.mapbefine.atlas.domain.Atlas;
+import com.mapbefine.mapbefine.atlas.domain.AtlasRepository;
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
-import com.mapbefine.mapbefine.bookmark.domain.Bookmark;
+import com.mapbefine.mapbefine.bookmark.domain.BookmarkRepository;
 import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.member.dto.response.MemberDetailResponse;
@@ -11,19 +12,33 @@ import com.mapbefine.mapbefine.member.exception.MemberErrorCode;
 import com.mapbefine.mapbefine.member.exception.MemberException.MemberNotFoundException;
 import com.mapbefine.mapbefine.pin.dto.response.PinResponse;
 import com.mapbefine.mapbefine.topic.domain.Topic;
+import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
-import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
 public class MemberQueryService {
 
     private final MemberRepository memberRepository;
+    private final AtlasRepository atlasRepository;
+    private final BookmarkRepository bookmarkRepository;
 
-    public MemberQueryService(MemberRepository memberRepository) {
+    private final TopicRepository topicRepository;
+
+    public MemberQueryService(
+            MemberRepository memberRepository,
+            AtlasRepository atlasRepository,
+            BookmarkRepository bookmarkRepository,
+            TopicRepository topicRepository
+    ) {
         this.memberRepository = memberRepository;
+        this.atlasRepository = atlasRepository;
+        this.bookmarkRepository = bookmarkRepository;
+        this.topicRepository = topicRepository;
     }
 
     public MemberDetailResponse findById(Long id) {
@@ -48,13 +63,11 @@ public class MemberQueryService {
     public List<TopicResponse> findAllTopicsInBookmark(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> bookMarkedTopics = findBookMarkedTopics(member);
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
-
+        List<Topic> bookMarkedTopics = topicRepository.findTopicsByBookmarksMemberId(authMember.getMemberId());
         return bookMarkedTopics.stream()
                 .map(topic -> TopicResponse.from(
                         topic,
-                        isInAtlas(topicsInAtlas, topic),
+                        isInAtlas(member.getId(), topic.getId()),
                         true
                 ))
                 .toList();
@@ -67,51 +80,40 @@ public class MemberQueryService {
                 .toList();
     }
 
-    private List<Topic> findBookMarkedTopics(Member member) {
-        return member.getBookmarks()
-                .stream()
-                .map(Bookmark::getTopic)
-                .toList();
-    }
-
-    private boolean isInAtlas(List<Topic> topicsInAtlas, Topic topic) {
-        return topicsInAtlas.contains(topic);
+    private boolean isInAtlas(Long memberId, Long topicId) {
+        return atlasRepository.existsByMemberIdAndTopicId(memberId, topicId);
     }
 
     public List<TopicResponse> findAllTopicsInAtlas(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> bookMarkedTopics = findBookMarkedTopics(member);
         List<Topic> topicsInAtlas = findTopicsInAtlas(member);
 
         return topicsInAtlas.stream()
                 .map(topic -> TopicResponse.from(
                         topic,
                         true,
-                        isBookMarked(bookMarkedTopics, topic)
+                        isInBookmark(authMember.getMemberId(), topic.getId())
                 ))
                 .toList();
     }
 
-    private boolean isBookMarked(List<Topic> bookMarkedTopics, Topic topic) {
-        return bookMarkedTopics.contains(topic);
+    private boolean isInBookmark(Long memberId, Long topicId) {
+        return bookmarkRepository.existsByMemberIdAndTopicId(memberId, topicId);
     }
 
     public List<TopicResponse> findMyAllTopics(AuthMember authMember) {
 
-        Member member = findMemberById(authMember.getMemberId());
-
-        List<Topic> bookMarkedTopics = findBookMarkedTopics(member);
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
+        Long memberId = authMember.getMemberId();
+        Member member = findMemberById(memberId);
 
         return member.getCreatedTopics()
                 .stream()
                 .map(topic -> TopicResponse.from(
                         topic,
-                        isInAtlas(topicsInAtlas, topic),
-                        isBookMarked(bookMarkedTopics, topic)
-                ))
-                .toList();
+                        isInAtlas(memberId, topic.getId()),
+                        isInBookmark(memberId, topic.getId())
+                )).toList();
     }
 
     public List<PinResponse> findMyAllPins(AuthMember authMember) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
@@ -11,7 +11,6 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,15 +38,15 @@ public class Pin extends BaseTimeEntity {
     @Embedded
     private PinInfo pinInfo;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "location_id", nullable = false)
     private Location location;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "topic_id", nullable = false)
     private Topic topic;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne
     @JoinColumn(name = "member_id")
     private Member creator;
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
@@ -11,6 +11,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -19,11 +20,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -37,15 +39,15 @@ public class Pin extends BaseTimeEntity {
     @Embedded
     private PinInfo pinInfo;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "location_id", nullable = false)
     private Location location;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "topic_id", nullable = false)
     private Topic topic;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member creator;
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
@@ -32,4 +32,5 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
     List<Pin> findAllByCreatorId(Long creatorId);
 
+
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
@@ -1,11 +1,13 @@
 package com.mapbefine.mapbefine.pin.domain;
 
-import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface PinRepository extends JpaRepository<Pin, Long> {
@@ -22,8 +24,12 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     @Query("update Pin p set p.isDeleted = true where p.creator.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
 
+    List<Pin> findAll();
+
+    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
     List<Pin> findAllByTopicId(Long topicId);
 
+    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
     List<Pin> findAllByCreatorId(Long creatorId);
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
@@ -3,9 +3,9 @@ package com.mapbefine.mapbefine.topic.application;
 import static com.mapbefine.mapbefine.topic.exception.TopicErrorCode.FORBIDDEN_TOPIC_READ;
 import static com.mapbefine.mapbefine.topic.exception.TopicErrorCode.TOPIC_NOT_FOUND;
 
-import com.mapbefine.mapbefine.atlas.domain.Atlas;
+import com.mapbefine.mapbefine.atlas.domain.AtlasRepository;
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
-import com.mapbefine.mapbefine.bookmark.domain.Bookmark;
+import com.mapbefine.mapbefine.bookmark.domain.BookmarkRepository;
 import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.topic.domain.Topic;
@@ -14,12 +14,13 @@ import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicForbiddenException;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -27,13 +28,19 @@ public class TopicQueryService {
 
     private final TopicRepository topicRepository;
     private final MemberRepository memberRepository;
+    private final AtlasRepository atlasRepository;
+    private final BookmarkRepository bookmarkRepository;
 
     public TopicQueryService(
             TopicRepository topicRepository,
-            MemberRepository memberRepository
+            MemberRepository memberRepository,
+            AtlasRepository atlasRepository,
+            BookmarkRepository bookmarkRepository
     ) {
         this.topicRepository = topicRepository;
         this.memberRepository = memberRepository;
+        this.atlasRepository = atlasRepository;
+        this.bookmarkRepository = bookmarkRepository;
     }
 
     public List<TopicResponse> findAllReadable(AuthMember authMember) {
@@ -54,15 +61,12 @@ public class TopicQueryService {
     private List<TopicResponse> getUserTopicResponses(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
-        List<Topic> topicsInBookMark = findBookMarkedTopics(member);
-
         return topicRepository.findAll().stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
                         topic,
-                        isInAtlas(topicsInAtlas, topic),
-                        isBookMarked(topicsInBookMark, topic)
+                        isInAtlas(member.getId(), topic.getId()),
+                        isBookMarked(member.getId(), topic.getId())
                 ))
                 .toList();
     }
@@ -72,26 +76,12 @@ public class TopicQueryService {
                 .orElseThrow(() -> new NoSuchElementException("findCreatorByAuthMember; member not found; id=" + id));
     }
 
-    private List<Topic> findTopicsInAtlas(Member member) {
-        return member.getAtlantes()
-                .stream()
-                .map(Atlas::getTopic)
-                .toList();
+    private boolean isInAtlas(Long memberId, Long topicId) {
+        return atlasRepository.existsByMemberIdAndTopicId(memberId, topicId);
     }
 
-    private List<Topic> findBookMarkedTopics(Member member) {
-        return member.getBookmarks()
-                .stream()
-                .map(Bookmark::getTopic)
-                .toList();
-    }
-
-    private boolean isInAtlas(List<Topic> topicsInAtlas, Topic topic) {
-        return topicsInAtlas.contains(topic);
-    }
-
-    private boolean isBookMarked(List<Topic> bookMarkedTopics, Topic topic) {
-        return bookMarkedTopics.contains(topic);
+    private boolean isBookMarked(Long memberId, Long topicId) {
+        return bookmarkRepository.existsByMemberIdAndTopicId(memberId, topicId);
     }
 
     public TopicDetailResponse findDetailById(AuthMember authMember, Long topicId) {
@@ -104,13 +94,10 @@ public class TopicQueryService {
 
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
-        List<Topic> topicsInBookMark = findBookMarkedTopics(member);
-
         return TopicDetailResponse.of(
                 topic,
-                isInAtlas(topicsInAtlas, topic),
-                isBookMarked(topicsInBookMark, topic),
+                isInAtlas(member.getId(), topic.getId()),
+                isBookMarked(member.getId(), topic.getId()),
                 authMember.canTopicUpdate(topic)
         );
     }
@@ -142,16 +129,11 @@ public class TopicQueryService {
     }
 
     private List<TopicDetailResponse> getUserTopicDetailResponses(AuthMember authMember, List<Topic> topics) {
-        Member member = findMemberById(authMember.getMemberId());
-
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
-        List<Topic> topicsInBookMark = findBookMarkedTopics(member);
-
         return topics.stream()
                 .map(topic -> TopicDetailResponse.of(
                         topic,
-                        isInAtlas(topicsInAtlas, topic),
-                        isBookMarked(topicsInBookMark, topic),
+                        isInAtlas(authMember.getMemberId(), topic.getId()),
+                        isBookMarked(authMember.getMemberId(), topic.getId()),
                         authMember.canTopicUpdate(topic)
                 ))
                 .toList();
@@ -190,19 +172,15 @@ public class TopicQueryService {
 
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
-        List<Topic> topicsInBookMark = findBookMarkedTopics(member);
-
         return topicRepository.findAllByCreatorId(memberId)
                 .stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
                         topic,
-                        isInAtlas(topicsInAtlas, topic),
-                        isBookMarked(topicsInBookMark, topic)
+                        isInAtlas(member.getId(), topic.getId()),
+                        isBookMarked(member.getId(), topic.getId())
                 )).
                 toList();
-
     }
 
     public List<TopicResponse> findAllByOrderByUpdatedAtDesc(AuthMember authMember) {
@@ -215,16 +193,13 @@ public class TopicQueryService {
     private List<TopicResponse> getUserNewestTopicResponse(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
-        List<Topic> topicsInBookMark = findBookMarkedTopics(member);
-
         return topicRepository.findAllByOrderByLastPinUpdatedAtDesc()
                 .stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
                         topic,
-                        isInAtlas(topicsInAtlas, topic),
-                        isBookMarked(topicsInBookMark, topic)
+                        isInAtlas(member.getId(), topic.getId()),
+                        isBookMarked(member.getId(), topic.getId())
                 )).
                 toList();
     }
@@ -256,18 +231,15 @@ public class TopicQueryService {
     private List<TopicResponse> getUserBestTopicResponse(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> topicsInAtlas = findTopicsInAtlas(member);
-        List<Topic> topicsInBookMark = findBookMarkedTopics(member);
-
         return topicRepository.findAll()
                 .stream()
                 .filter(authMember::canRead)
                 .sorted(Comparator.comparing(Topic::countBookmarks).reversed())
                 .map(topic -> TopicResponse.from(
                         topic,
-                        isInAtlas(topicsInAtlas, topic),
-                        isBookMarked((topicsInBookMark), topic))
-                ).toList();
+                        isInAtlas(member.getId(), topic.getId()),
+                        isBookMarked(member.getId(), topic.getId())
+                )).toList();
     }
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
@@ -11,6 +11,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,12 +19,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -40,18 +44,22 @@ public class Topic extends BaseTimeEntity {
     @Embedded
     private TopicStatus topicStatus;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member creator;
 
     @OneToMany(mappedBy = "topic")
-    private List<Permission> permissions = new ArrayList<>();
+    private Set<Permission> permissions = new HashSet<>();
 
     @OneToMany(mappedBy = "topic", cascade = CascadeType.PERSIST)
     private List<Pin> pins = new ArrayList<>();
 
     @OneToMany(mappedBy = "topic")
-    private List<Bookmark> bookmarks = new ArrayList<>();
+    private Set<Bookmark> bookmarks = new HashSet<>();
+
+    @Column(nullable = false)
+    @ColumnDefault(value = "0")
+    private int pinCount = 0;
 
     @Column(nullable = false)
     @ColumnDefault(value = "false")
@@ -109,11 +117,12 @@ public class Topic extends BaseTimeEntity {
     }
 
     public int countPins() {
-        return pins.size();
+        return pinCount;
     }
 
     public void addPin(Pin pin) {
         pins.add(pin);
+        pinCount++;
     }
 
     public void addBookmark(Bookmark bookmark) {
@@ -135,4 +144,7 @@ public class Topic extends BaseTimeEntity {
         this.topicInfo = topicInfo.removeImage();
     }
 
+    public void setPinCount(int count){
+        this.pinCount = count;
+    }
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
@@ -24,9 +24,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 @Entity
@@ -52,14 +50,18 @@ public class Topic extends BaseTimeEntity {
     private Set<Permission> permissions = new HashSet<>();
 
     @OneToMany(mappedBy = "topic", cascade = CascadeType.PERSIST)
-    private List<Pin> pins = new ArrayList<>();
+    private Set<Pin> pins = new HashSet<>();
 
-    @OneToMany(mappedBy = "topic")
+    @OneToMany(mappedBy = "topic", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private Set<Bookmark> bookmarks = new HashSet<>();
 
     @Column(nullable = false)
     @ColumnDefault(value = "0")
     private int pinCount = 0;
+
+    @Column(nullable = false)
+    @ColumnDefault(value = "0")
+    private int bookmarkCount = 0;
 
     @Column(nullable = false)
     @ColumnDefault(value = "false")
@@ -127,6 +129,7 @@ public class Topic extends BaseTimeEntity {
 
     public void addBookmark(Bookmark bookmark) {
         bookmarks.add(bookmark);
+        bookmarkCount++;
     }
 
     public void addMemberTopicPermission(Permission permission) {
@@ -134,17 +137,19 @@ public class Topic extends BaseTimeEntity {
     }
 
     public int countBookmarks() {
-        return bookmarks.size();
+        return bookmarkCount;
     }
 
     public Publicity getPublicity() {
         return topicStatus.getPublicity();
     }
+
     public void removeImage() {
         this.topicInfo = topicInfo.removeImage();
     }
 
-    public void setPinCount(int count){
-        this.pinCount = count;
+    public void removeBookmark(Bookmark bookmark) {
+        bookmarks.remove(bookmark);
+        bookmarkCount--;
     }
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
@@ -8,10 +8,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TopicRepository extends JpaRepository<Topic, Long> {
 
+    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
+    Optional<Topic> findById(Long id);
+
+    @EntityGraph(attributePaths = {"creator", "permissions"})
     List<Topic> findByIdIn(List<Long> ids);
 
     boolean existsById(Long id);
@@ -33,4 +38,5 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     @Query("update Topic t set t.isDeleted = true where t.creator.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
 
+    List<Topic> findTopicsByBookmarksMemberId(Long memberId);
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
@@ -1,11 +1,13 @@
 package com.mapbefine.mapbefine.topic.domain;
 
-import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface TopicRepository extends JpaRepository<Topic, Long> {
@@ -14,8 +16,13 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
 
     boolean existsById(Long id);
 
+    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
+    List<Topic> findAll();
+
+    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
     List<Topic> findAllByOrderByLastPinUpdatedAtDesc();
 
+    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
     List<Topic> findAllByCreatorId(Long creatorId);
 
     @Modifying(clearAutomatically = true)

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/AdminIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/AdminIntegrationTest.java
@@ -24,17 +24,15 @@ import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import io.restassured.common.mapper.TypeRef;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
 
 class AdminIntegrationTest extends IntegrationTest {
 
@@ -52,6 +50,7 @@ class AdminIntegrationTest extends IntegrationTest {
 
     @Autowired
     private PinImageRepository pinImageRepository;
+
     @Value("${security.admin.key}")
     private String secretKey;
 
@@ -67,6 +66,7 @@ class AdminIntegrationTest extends IntegrationTest {
         topic = topicRepository.save(TopicFixture.createByName("topic", member));
         location = locationRepository.save(LocationFixture.create());
         pin = pinRepository.save(PinFixture.create(location, topic, member));
+        topic = topicRepository.save(topic);
         pinImage = pinImageRepository.save(PinImageFixture.create(pin));
     }
 
@@ -124,7 +124,7 @@ class AdminIntegrationTest extends IntegrationTest {
                 .extract()
                 .as(new TypeRef<>() {
                 });
-
+        System.out.println("====" + topic.getPinCount());
         //then
 
         AdminMemberDetailResponse expected = AdminMemberDetailResponse.of(

--- a/backend/src/test/java/com/mapbefine/mapbefine/auth/application/TokenServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/auth/application/TokenServiceTest.java
@@ -9,9 +9,6 @@ import com.mapbefine.mapbefine.member.MemberFixture;
 import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.member.domain.Role;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -20,6 +17,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.TestPropertySource;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Optional;
 
 @DataJpaTest
 @TestPropertySource(locations = "classpath:application.yml")

--- a/backend/src/test/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandServiceTest.java
@@ -181,21 +181,24 @@ class BookmarkCommandServiceTest {
         topicRepository.save(topic2);
 
         Bookmark bookmark1 = Bookmark.createWithAssociatedTopicAndMember(topic1, creatorBefore);
-        Bookmark bookmark2 = Bookmark.createWithAssociatedTopicAndMember(topic1, creatorBefore);
+        Bookmark bookmark2 = Bookmark.createWithAssociatedTopicAndMember(topic2, creatorBefore);
 
         bookmarkRepository.save(bookmark1);
         bookmarkRepository.save(bookmark2);
+
+        testEntityManager.flush();
+        testEntityManager.clear();
 
         //when
         assertThat(creatorBefore.getBookmarks()).hasSize(2);
 
         AuthMember user = MemberFixture.createUser(creatorBefore);
         bookmarkCommandService.deleteAllBookmarks(user);
-
         testEntityManager.flush();
         testEntityManager.clear();
 
         //then
+        assertThat(bookmarkRepository.findById(creatorBefore.getId())).isEmpty();
         Member creatorAfter = memberRepository.findById(creatorBefore.getId()).get();
         assertThat(creatorAfter.getBookmarks()).isEmpty();
     }

--- a/backend/src/test/java/com/mapbefine/mapbefine/permission/domain/PermissionTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/permission/domain/PermissionTest.java
@@ -7,9 +7,11 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
 
 class PermissionTest {
 
@@ -52,7 +54,7 @@ class PermissionTest {
         Permission permission =
                 Permission.createPermissionAssociatedWithTopicAndMember(topic, member);
         List<Topic> topicsWithPermission = member.getTopicsWithPermissions();
-        List<Permission> permissions = topic.getPermissions();
+        Set<Permission> permissions = topic.getPermissions();
 
         // then
         assertThat(topicsWithPermission).hasSize(1);
@@ -60,7 +62,7 @@ class PermissionTest {
         assertThat(topicsWithPermission.get(0)).usingRecursiveComparison()
                 .ignoringFields("createdAt", "updatedAt")
                 .isEqualTo(topic);
-        assertThat(permissions.get(0)).usingRecursiveComparison()
+        assertThat(permissions.iterator().next()).usingRecursiveComparison()
                 .ignoringFields("createdAt", "updatedAt")
                 .isEqualTo(permission);
     }

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinTest.java
@@ -9,11 +9,13 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
 
 class PinTest {
 
@@ -47,7 +49,7 @@ class PinTest {
         );
 
         List<Pin> pinsInLocation = location.getPins();
-        List<Pin> pinsInTopic = topic.getPins();
+        Set<Pin> pinsInTopic = topic.getPins();
         List<Pin> pinsInMember = member.getCreatedPins();
 
         // then
@@ -56,7 +58,7 @@ class PinTest {
         assertThat(pinsInMember).hasSize(1);
         assertThat(pinsInLocation.get(0)).usingRecursiveComparison()
                 .isEqualTo(pin);
-        assertThat(pinsInTopic.get(0)).usingRecursiveComparison()
+        assertThat(pinsInTopic.iterator().next()).usingRecursiveComparison()
                 .isEqualTo(pin);
         assertThat(pinsInMember.get(0)).usingRecursiveComparison()
                 .isEqualTo(pin);
@@ -79,7 +81,7 @@ class PinTest {
 
         // when
         original.copyToTopic(memberForCopy, topicForCopy);
-        Pin actual = topicForCopy.getPins().get(0);
+        Pin actual = topicForCopy.getPins().iterator().next();
 
         // then
         assertThat(original).usingRecursiveComparison()

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/TopicIntegrationTest.java
@@ -21,7 +21,6 @@ import com.mapbefine.mapbefine.topic.domain.Publicity;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequestWithoutImage;
-import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequest;
 import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequestWithoutImage;
 import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
@@ -29,15 +28,16 @@ import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.io.File;
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 class TopicIntegrationTest extends IntegrationTest {
 
@@ -414,6 +414,8 @@ class TopicIntegrationTest extends IntegrationTest {
         Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(bestOneTopic, member);
         bookmarkRepository.save(bookmark);
 
+        topicRepository.save(bestOneTopic);
+
         // when
         List<TopicResponse> expect = List.of(
                 TopicResponse.from(bestOneTopic, Boolean.FALSE, Boolean.TRUE),
@@ -460,6 +462,7 @@ class TopicIntegrationTest extends IntegrationTest {
         );
 
         pinRepository.saveAll(pins);
+        topicRepository.saveAll(List.of(topic1, topic2, topic3));
 
         // when
         ExtractableResponse<Response> response = RestAssured

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
@@ -29,12 +29,14 @@ import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicBadRequestException;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicForbiddenException;
-import java.util.Collections;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 @ServiceTest
 class TopicCommandServiceTest {
@@ -310,8 +312,8 @@ class TopicCommandServiceTest {
         topicCommandService.copyPin(user, target.getId(), pinIds);
 
         // then
-        List<Pin> targetPins = target.getPins();
-        Pin targetPin = targetPins.get(0);
+        Set<Pin> targetPins = target.getPins();
+        Pin targetPin = targetPins.iterator().next();
         Pin sourcePin = sourcePins.get(0);
 
         assertThat(targetPins).hasSize(sourcePins.size());


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
성능 개선을 위해 조회 쿼리를 개선하였습니다. (항상 필요한 정보를 지연 로딩 대신 즉시 로딩 + fetch 조인 적용)

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
`@EntityGraph`를 이용해 fetch join으로 조회하도록 합니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
3인 페어로 진행하여, 준팍 확인하시면 머지 진행하도록 하겠습니다!

(노션의 BE 공간 - 쿼리 개선 기록 참조)

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
closed #494

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
