### PR TITLE
[FE] Refactor/#513 지도 생성 및 핀 생성 페이지 지도 위치 조정

### DIFF
--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -97,7 +97,6 @@ const MediaWrapper = styled.section<{
   overflow: hidden;
   @media (max-width: 1076px) {
     flex-direction: ${({ $isAddPage, $layoutWidth }) => {
-      if ($isAddPage) return 'column';
       if ($layoutWidth === '372px') return 'column-reverse';
     }};
   }

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -37,7 +37,8 @@ const NewPin = () => {
   const [topic, setTopic] = useState<any>(null);
   const [selectedTopic, setSelectedTopic] = useState<any>(null);
   const [showedImages, setShowedImages] = useState<string[]>([]);
-  const { clickedMarker } = useContext(MarkerContext);
+  const { clickedMarker, markers, removeMarkers, removeInfowindows } =
+    useContext(MarkerContext);
   const { clickedCoordinate, setClickedCoordinate } =
     useContext(CoordinatesContext);
   const { formValues, errorMessages, onChangeInput } =
@@ -228,6 +229,11 @@ const NewPin = () => {
       }
     };
 
+    if (!topicId && markers && markers.length > 0) {
+      removeMarkers();
+      removeInfowindows();
+    }
+
     getTopicId();
   }, []);
 
@@ -307,7 +313,6 @@ const NewPin = () => {
             onChangeInput={onChangeInput}
             tabIndex={1}
             errorMessage={errorMessages.name}
-            autoFocus
             maxLength={50}
           />
 
@@ -364,6 +369,7 @@ const NewPin = () => {
               추가하기
             </Button>
           </Flex>
+          <Space size={7} />
         </Wrapper>
       </form>
 

--- a/frontend/src/pages/NewTopic.tsx
+++ b/frontend/src/pages/NewTopic.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import Text from '../components/common/Text';
 import Flex from '../components/common/Flex';
 import Space from '../components/common/Space';
@@ -18,6 +18,7 @@ import usePost from '../apiHooks/usePost';
 import AuthorityRadioContainer from '../components/AuthorityRadioContainer';
 import styled from 'styled-components';
 import useCompressImage from '../hooks/useCompressImage';
+import { MarkerContext } from '../context/MarkerContext';
 
 type NewTopicFormValuesType = Omit<NewTopicFormProps, 'topics'>;
 
@@ -36,6 +37,8 @@ const NewTopic = () => {
       image: '',
     });
   const { compressImage } = useCompressImage();
+  const { markers, removeMarkers, removeInfowindows } =
+    useContext(MarkerContext);
 
   const [isPrivate, setIsPrivate] = useState(false); // 혼자 볼 지도 :  같이 볼 지도
   const [isAllPermissioned, setIsAllPermissioned] = useState(true); // 모두 : 지정 인원
@@ -137,10 +140,17 @@ const NewTopic = () => {
     setShowImage(URL.createObjectURL(file));
   };
 
+  useEffect(() => {
+    if (!pulledPinIds && markers && markers.length > 0) {
+      removeMarkers();
+      removeInfowindows();
+    }
+  }, []);
+
   return (
     <form onSubmit={onSubmit}>
       <Space size={4} />
-      <Flex
+      <Wrapper
         width={`calc(${width} - ${LAYOUT_PADDING})`}
         $flexDirection="column"
       >
@@ -237,10 +247,24 @@ const NewTopic = () => {
             생성하기
           </Button>
         </Flex>
-      </Flex>
+        <Space size={7} />
+      </Wrapper>
     </form>
   );
 };
+
+const Wrapper = styled(Flex)`
+  margin: 0 auto;
+
+  @media (max-width: 1076px) {
+    width: calc(50vw - 40px);
+  }
+
+  @media (max-width: 744px) {
+    width: ${({ width }) => width};
+    margin: 0 auto;
+  }
+`;
 
 const ImageInputLabel = styled.label`
   height: 40px;

--- a/frontend/src/pages/SeeTogetherTopics.tsx
+++ b/frontend/src/pages/SeeTogetherTopics.tsx
@@ -130,6 +130,8 @@ const Wrapper = styled.section<{ width: '372px' | '100vw' }>`
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  margin: 0 auto;
 `;
 
 const WrapperWhenEmpty = styled.section<{ width: '372px' | '100vw' }>`
@@ -139,11 +141,13 @@ const WrapperWhenEmpty = styled.section<{ width: '372px' | '100vw' }>`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+
+  margin: 0 auto;
 `;
 
 const ButtonsWrapper = styled.div`
   display: flex;
-  justify-content: center;
+  justify-content: end;
   align-items: center;
 `;
 


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
* 지도생성 및 핀 생성 페이지에서 지도 상하가 반전되어 나오는 정책을 변경한다. (지도: 상 , 사이드바: 하 로 모든 페이지를 고정한다.)
* 핀 생성 페이지 접속 시 장소 이름으로 오토 포커스 되는 기능을 제거한다.
* 지도 단일 조회 이후 지도 생성, 핀생성 페이지 이동 시 기존에 조회한 핀이 잔류하던 문제를 해결한다.

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] 지도생성 및 핀 생성 페이지에서 지도 상하가 반전되어 나오는 정책을 변경한다. (지도: 상 , 사이드바: 하 로 모든 페이지를 고정한다.)
- [x] 핀 생성 페이지 접속 시 장소 이름으로 오토 포커스 되는 기능을 제거한다.
- [x] 지도 단일 조회 이후 지도 생성, 핀생성 페이지 이동 시 기존에 조회한 핀이 잔류하던 문제를 해결한다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
close #513 
## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
