### PR TITLE
Hotfix: 토픽 조회시 순서 보장하도록 수정 

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
@@ -19,12 +19,11 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreUpdate;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
@@ -20,8 +20,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
-import java.util.LinkedHashSet;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -46,13 +46,13 @@ public class Topic extends BaseTimeEntity {
     private Member creator;
 
     @OneToMany(mappedBy = "topic")
-    private Set<Permission> permissions = new LinkedHashSet<>();
+    private List<Permission> permissions = new ArrayList<>();
 
     @OneToMany(mappedBy = "topic", cascade = CascadeType.PERSIST)
-    private Set<Pin> pins = new LinkedHashSet<>();
+    private List<Pin> pins = new ArrayList<>();
 
     @OneToMany(mappedBy = "topic", cascade = CascadeType.PERSIST, orphanRemoval = true)
-    private Set<Bookmark> bookmarks = new LinkedHashSet<>();
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
     @Column(nullable = false)
     @ColumnDefault(value = "0")

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
@@ -1,14 +1,13 @@
 package com.mapbefine.mapbefine.topic.domain;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface TopicRepository extends JpaRepository<Topic, Long> {
@@ -21,13 +20,13 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
 
     boolean existsById(Long id);
 
-    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
+    @EntityGraph(attributePaths = {"creator", "permissions"})
     List<Topic> findAll();
 
-    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
+    @EntityGraph(attributePaths = {"creator", "permissions"})
     List<Topic> findAllByOrderByLastPinUpdatedAtDesc();
 
-    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
+    @EntityGraph(attributePaths = {"creator", "permissions"})
     List<Topic> findAllByCreatorId(Long creatorId);
 
     @Modifying(clearAutomatically = true)

--- a/backend/src/test/java/com/mapbefine/mapbefine/permission/domain/PermissionTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/permission/domain/PermissionTest.java
@@ -54,7 +54,7 @@ class PermissionTest {
         Permission permission =
                 Permission.createPermissionAssociatedWithTopicAndMember(topic, member);
         List<Topic> topicsWithPermission = member.getTopicsWithPermissions();
-        Set<Permission> permissions = topic.getPermissions();
+        List<Permission> permissions = topic.getPermissions();
 
         // then
         assertThat(topicsWithPermission).hasSize(1);

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinTest.java
@@ -49,7 +49,7 @@ class PinTest {
         );
 
         List<Pin> pinsInLocation = location.getPins();
-        Set<Pin> pinsInTopic = topic.getPins();
+        List<Pin> pinsInTopic = topic.getPins();
         List<Pin> pinsInMember = member.getCreatedPins();
 
         // then

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
@@ -312,7 +312,7 @@ class TopicCommandServiceTest {
         topicCommandService.copyPin(user, target.getId(), pinIds);
 
         // then
-        Set<Pin> targetPins = target.getPins();
+        List<Pin> targetPins = target.getPins();
         Pin targetPin = targetPins.iterator().next();
         Pin sourcePin = sourcePins.get(0);
 


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
Topic
## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
Topic 클래스의 자료구조를 List로 변경하였습니다.
기존에 multiple Bag(?) 오류로 인해, Set을 사용하였는데 이 경우, 데이터베이스에서 데이터를 읽어올 때, 순서를 보장하지 않게 됩니다.
어플리케이션 단에서 순서가 보장되지 않아서 문제가 발생하는 것이 아니라, 데이터베이스에서 읽어올 때 발생하는 문제입니다.
이에 따라, 기존 매튜의 hotfix로 문제가 해결되지 않았던 것입니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
성능 개선 과정에서, Bookmark count를 컬럼으로 추가함에 따라 기존 `@EntityGraph` 사용시 함께 fetch join 해오던 Bookmarks를 제거하였습니다.
이로 인해, mutliple bag 관련 예외가 발생하지 않으며, 데이터의 기존 순서 또한 보장될 수 있습니다.

**참고 사항**
별개로, 현재 프론트엔드에서 토픽을 상세조회할 때 2번의 API 요청이 발생하고 있습니다.
또한, 토픽 내의 핀의 정보를 클릭할 때마다, 토픽 상세 조회 API를 호출하고 있습니다.
이 부분은 세인 및 아이크에게 전달된 사항입니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
