### PR TITLE
[BE] Hotfix/#473 Soft Delete 반영해 조회하도록 쿼리 수정

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
@@ -91,7 +91,7 @@ public class AdminCommandService {
     }
 
     private Topic findTopicById(Long topicId) {
-        return topicRepository.findById(topicId)
+        return topicRepository.findByIdAndIsDeletedFalse(topicId)
                 .orElseThrow(() -> new TopicException.TopicNotFoundException(TOPIC_NOT_FOUND, List.of(topicId)));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/atlas/application/AtlasCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/atlas/application/AtlasCommandService.java
@@ -13,10 +13,11 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import java.util.NoSuchElementException;
-import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -72,7 +73,7 @@ public class AtlasCommandService {
     }
 
     private Topic findTopicById(Long topicId) {
-        return topicRepository.findById(topicId)
+        return topicRepository.findByIdAndIsDeletedFalse(topicId)
                 .orElseThrow(() -> new AtlasBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandService.java
@@ -53,7 +53,7 @@ public class BookmarkCommandService {
     }
 
     private Topic getTopicById(Long topicId) {
-        return topicRepository.findById(topicId)
+        return topicRepository.findByIdAndIsDeletedFalse(topicId)
                 .orElseThrow(() -> new BookmarkBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
@@ -63,7 +63,7 @@ public class MemberQueryService {
     public List<TopicResponse> findAllTopicsInBookmark(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> bookMarkedTopics = topicRepository.findTopicsByBookmarksMemberId(authMember.getMemberId());
+        List<Topic> bookMarkedTopics = topicRepository.findTopicsByBookmarksMemberIdAndIsDeletedFalse(authMember.getMemberId());
         return bookMarkedTopics.stream()
                 .map(topic -> TopicResponse.from(
                         topic,

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionCommandService.java
@@ -15,10 +15,11 @@ import com.mapbefine.mapbefine.permission.exception.PermissionException.Permissi
 import com.mapbefine.mapbefine.permission.exception.PermissionException.PermissionForbiddenException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import java.util.List;
-import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
 
 @Service
 @Transactional
@@ -77,7 +78,7 @@ public class PermissionCommandService {
 
     private Topic findTopic(PermissionRequest request) {
         Long topicId = request.topicId();
-        return topicRepository.findById(topicId)
+        return topicRepository.findByIdAndIsDeletedFalse(topicId)
                 .orElseThrow(() -> new PermissionBadRequestException(ILLEGAL_TOPIC_ID, topicId));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionQueryService.java
@@ -14,9 +14,10 @@ import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.domain.TopicStatus;
 import com.mapbefine.mapbefine.topic.exception.TopicErrorCode;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicNotFoundException;
-import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -42,7 +43,7 @@ public class PermissionQueryService {
     }
 
     private Publicity findTopicPublicityById(Long topicId) {
-        return topicRepository.findById(topicId)
+        return topicRepository.findByIdAndIsDeletedFalse(topicId)
                 .map(Topic::getTopicStatus)
                 .map(TopicStatus::getPublicity)
                 .orElseThrow(() -> new TopicNotFoundException(TopicErrorCode.TOPIC_NOT_FOUND, topicId));

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
@@ -182,7 +182,7 @@ public class PinCommandService {
     }
 
     private PinImage findPinImage(Long pinImageId) {
-        return pinImageRepository.findById(pinImageId)
+        return pinImageRepository.findByIdAndIsDeletedFalse(pinImageId)
                 .orElseThrow(() -> new PinBadRequestException(ILLEGAL_PIN_IMAGE_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
@@ -146,7 +146,7 @@ public class PinCommandService {
     }
 
     private Pin findPin(Long pinId) {
-        return pinRepository.findById(pinId)
+        return pinRepository.findByIdAndIsDeletedFalse(pinId)
                 .orElseThrow(() -> new PinBadRequestException(ILLEGAL_PIN_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
@@ -1,12 +1,14 @@
 package com.mapbefine.mapbefine.pin.application;
 
+import static com.mapbefine.mapbefine.image.exception.ImageErrorCode.IMAGE_FILE_IS_NULL;
 import static com.mapbefine.mapbefine.pin.exception.PinErrorCode.FORBIDDEN_PIN_CREATE_OR_UPDATE;
 import static com.mapbefine.mapbefine.pin.exception.PinErrorCode.ILLEGAL_PIN_ID;
 import static com.mapbefine.mapbefine.pin.exception.PinErrorCode.ILLEGAL_PIN_IMAGE_ID;
-import static com.mapbefine.mapbefine.image.exception.ImageErrorCode.IMAGE_FILE_IS_NULL;
 import static com.mapbefine.mapbefine.topic.exception.TopicErrorCode.ILLEGAL_TOPIC_ID;
 
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
+import com.mapbefine.mapbefine.image.application.ImageService;
+import com.mapbefine.mapbefine.image.exception.ImageException.ImageBadRequestException;
 import com.mapbefine.mapbefine.location.domain.Address;
 import com.mapbefine.mapbefine.location.domain.Coordinate;
 import com.mapbefine.mapbefine.location.domain.Location;
@@ -22,17 +24,16 @@ import com.mapbefine.mapbefine.pin.dto.request.PinImageCreateRequest;
 import com.mapbefine.mapbefine.pin.dto.request.PinUpdateRequest;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinBadRequestException;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
-import com.mapbefine.mapbefine.image.application.ImageService;
-import com.mapbefine.mapbefine.image.exception.ImageException.ImageBadRequestException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicBadRequestException;
-import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Objects;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Objects;
 
 @Transactional
 @Service
@@ -99,7 +100,7 @@ public class PinCommandService {
         if (Objects.isNull(topicId)) {
             throw new TopicBadRequestException(ILLEGAL_TOPIC_ID);
         }
-        return topicRepository.findById(topicId)
+        return topicRepository.findByIdAndIsDeletedFalse(topicId)
                 .orElseThrow(() -> new TopicBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinQueryService.java
@@ -11,9 +11,10 @@ import com.mapbefine.mapbefine.pin.dto.response.PinResponse;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinNotFoundException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
-import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional(readOnly = true)
 @Service
@@ -25,18 +26,16 @@ public class PinQueryService {
         this.pinRepository = pinRepository;
     }
 
-    // TODO: 2023/08/08 isDeleted 제외하고 조회하기
     public List<PinResponse> findAllReadable(AuthMember member) {
-        return pinRepository.findAll()
+        return pinRepository.findAllByIsDeletedFalse()
                 .stream()
                 .filter(pin -> member.canRead(pin.getTopic()))
                 .map(PinResponse::from)
                 .toList();
     }
 
-    // TODO: 2023/08/08 isDeleted 제외하고 조회하기
     public PinDetailResponse findDetailById(AuthMember member, Long pinId) {
-        Pin pin = pinRepository.findById(pinId)
+        Pin pin = pinRepository.findByIdAndIsDeletedFalse(pinId)
                 .orElseThrow(() -> new PinNotFoundException(PIN_NOT_FOUND, pinId));
         validateReadAuth(member, pin.getTopic());
 
@@ -52,7 +51,7 @@ public class PinQueryService {
     }
 
     public List<PinResponse> findAllPinsByMemberId(AuthMember authMember, Long memberId) {
-        return pinRepository.findAllByCreatorId(memberId)
+        return pinRepository.findAllByCreatorIdAndIsDeletedFalse(memberId)
                 .stream()
                 .filter(pin -> authMember.canRead(pin.getTopic()))
                 .map(PinResponse::from)

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinImageRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinImageRepository.java
@@ -1,14 +1,20 @@
 package com.mapbefine.mapbefine.pin.domain;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface PinImageRepository extends JpaRepository<PinImage, Long> {
+
+    Optional<PinImage> findByIdAndIsDeletedFalse(Long pinId);
+
+    List<PinImage> findAllByPinIdAndIsDeletedFalse(Long pinId);
 
     @Modifying(clearAutomatically = true)
     @Query("update PinImage p set p.isDeleted = true where p.pin.id = :pinId")
@@ -21,6 +27,4 @@ public interface PinImageRepository extends JpaRepository<PinImage, Long> {
     @Modifying(clearAutomatically = true)
     @Query("update PinImage p set p.isDeleted = true where p.pin.id in :pinIds")
     void deleteAllByPinIds(@Param("pinIds") List<Long> pinIds);
-
-    List<PinImage> findAllByPinId(Long pinId);
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
@@ -8,9 +8,24 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface PinRepository extends JpaRepository<Pin, Long> {
+
+    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
+    List<Pin> findAllByIsDeletedFalse();
+
+    Optional<Pin> findByIdAndIsDeletedFalse(Long pinId);
+
+    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
+    List<Pin> findAllByTopicId(Long topicId);
+
+    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
+    List<Pin> findAllByCreatorIdAndIsDeletedFalse(Long creatorId);
+
+    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
+    List<Pin> findAllByCreatorId(Long creatorId);
 
     @Modifying(clearAutomatically = true)
     @Query("update Pin p set p.isDeleted = true where p.topic.id = :topicId")
@@ -23,14 +38,5 @@ public interface PinRepository extends JpaRepository<Pin, Long> {
     @Modifying(clearAutomatically = true)
     @Query("update Pin p set p.isDeleted = true where p.creator.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
-
-    List<Pin> findAll();
-
-    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
-    List<Pin> findAllByTopicId(Long topicId);
-
-    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
-    List<Pin> findAllByCreatorId(Long creatorId);
-
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -8,13 +8,13 @@ import static com.mapbefine.mapbefine.topic.exception.TopicErrorCode.FORBIDDEN_T
 import static com.mapbefine.mapbefine.topic.exception.TopicErrorCode.ILLEGAL_TOPIC_ID;
 
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
+import com.mapbefine.mapbefine.image.application.ImageService;
 import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.pin.domain.Pin;
 import com.mapbefine.mapbefine.pin.domain.PinRepository;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinBadRequestException;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
-import com.mapbefine.mapbefine.image.application.ImageService;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.dto.request.TopicCreateRequest;
@@ -22,13 +22,14 @@ import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequest;
 import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicBadRequestException;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicForbiddenException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @Service
@@ -55,7 +56,7 @@ public class TopicCommandService {
         Topic topic = convertToTopic(member, request);
         List<Long> pinIds = request.pins();
 
-        if (0 < pinIds.size()) {
+        if (!pinIds.isEmpty()) {
             copyPinsToTopic(member, topic, pinIds);
         }
 
@@ -159,7 +160,7 @@ public class TopicCommandService {
     }
 
     private List<Topic> findAllTopics(List<Long> topicIds) {
-        List<Topic> findTopics = topicRepository.findAllById(topicIds);
+        List<Topic> findTopics = topicRepository.findByIdInAndIsDeletedFalse(topicIds);
 
         if (topicIds.size() != findTopics.size()) {
             throw new TopicBadRequestException(ILLEGAL_TOPIC_ID);
@@ -195,7 +196,7 @@ public class TopicCommandService {
     }
 
     private Topic findTopic(Long topicId) {
-        return topicRepository.findById(topicId)
+        return topicRepository.findByIdAndIsDeletedFalse(topicId)
                 .orElseThrow(() -> new TopicBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
@@ -51,7 +51,7 @@ public class TopicQueryService {
     }
 
     private List<TopicResponse> getGuestTopicResponses(AuthMember authMember) {
-        return topicRepository.findAll()
+        return topicRepository.findAllByIsDeletedFalse()
                 .stream()
                 .filter(authMember::canRead)
                 .map(TopicResponse::fromGuestQuery)
@@ -61,7 +61,7 @@ public class TopicQueryService {
     private List<TopicResponse> getUserTopicResponses(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAll().stream()
+        return topicRepository.findAllByIsDeletedFalse().stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
                         topic,
@@ -103,7 +103,7 @@ public class TopicQueryService {
     }
 
     private Topic findTopic(Long id) {
-        return topicRepository.findById(id)
+        return topicRepository.findByIdAndIsDeletedFalse(id)
                 .orElseThrow(() -> new TopicNotFoundException(TOPIC_NOT_FOUND, List.of(id)));
     }
 
@@ -116,7 +116,7 @@ public class TopicQueryService {
     }
 
     public List<TopicDetailResponse> findDetailsByIds(AuthMember authMember, List<Long> ids) {
-        List<Topic> topics = topicRepository.findByIdIn(ids);
+        List<Topic> topics = topicRepository.findByIdInAndIsDeletedFalse(ids);
 
         validateTopicsCount(ids, topics);
         validateReadableTopics(authMember, topics);
@@ -163,7 +163,7 @@ public class TopicQueryService {
     public List<TopicResponse> findAllTopicsByMemberId(AuthMember authMember, Long memberId) {
 
         if (Objects.isNull(authMember.getMemberId())) {
-            return topicRepository.findAllByCreatorId(memberId)
+            return topicRepository.findAllByCreatorIdAndIsDeletedFalse(memberId)
                     .stream()
                     .filter(authMember::canRead)
                     .map(TopicResponse::fromGuestQuery)
@@ -172,7 +172,7 @@ public class TopicQueryService {
 
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAllByCreatorId(memberId)
+        return topicRepository.findAllByCreatorIdAndIsDeletedFalse(memberId)
                 .stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
@@ -193,7 +193,7 @@ public class TopicQueryService {
     private List<TopicResponse> getUserNewestTopicResponse(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAllByOrderByLastPinUpdatedAtDesc()
+        return topicRepository.findAllByIsDeletedFalseOrderByLastPinUpdatedAtDesc()
                 .stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
@@ -205,7 +205,7 @@ public class TopicQueryService {
     }
 
     private List<TopicResponse> getGuestNewestTopicResponse(AuthMember authMember) {
-        return topicRepository.findAllByOrderByLastPinUpdatedAtDesc()
+        return topicRepository.findAllByIsDeletedFalseOrderByLastPinUpdatedAtDesc()
                 .stream()
                 .filter(authMember::canRead)
                 .map(TopicResponse::fromGuestQuery)
@@ -220,7 +220,7 @@ public class TopicQueryService {
     }
 
     private List<TopicResponse> getGuestBestTopicResponse(AuthMember authMember) {
-        return topicRepository.findAll()
+        return topicRepository.findAllByIsDeletedFalse()
                 .stream()
                 .filter(authMember::canRead)
                 .sorted(Comparator.comparing(Topic::countBookmarks).reversed())
@@ -231,7 +231,7 @@ public class TopicQueryService {
     private List<TopicResponse> getUserBestTopicResponse(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAll()
+        return topicRepository.findAllByIsDeletedFalse()
                 .stream()
                 .filter(authMember::canRead)
                 .sorted(Comparator.comparing(Topic::countBookmarks).reversed())

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
@@ -1,7 +1,5 @@
 package com.mapbefine.mapbefine.topic.domain;
 
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -9,25 +7,32 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface TopicRepository extends JpaRepository<Topic, Long> {
 
-    @EntityGraph(attributePaths = {"creator", "permissions", "bookmarks"})
-    Optional<Topic> findById(Long id);
+    @EntityGraph(attributePaths = {"creator", "permissions"})
+    Optional<Topic> findByIdAndIsDeletedFalse(Long id);
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findByIdIn(List<Long> ids);
-
-    boolean existsById(Long id);
+    List<Topic> findAllByIsDeletedFalse();
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findAll();
+    List<Topic> findByIdInAndIsDeletedFalse(List<Long> ids);
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findAllByOrderByLastPinUpdatedAtDesc();
+    List<Topic> findAllByIsDeletedFalseOrderByLastPinUpdatedAtDesc();
+
+    @EntityGraph(attributePaths = {"creator", "permissions"})
+    List<Topic> findAllByCreatorIdAndIsDeletedFalse(Long creatorId);
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
     List<Topic> findAllByCreatorId(Long creatorId);
+
+    @EntityGraph(attributePaths = {"creator", "permissions"})
+    List<Topic> findTopicsByBookmarksMemberIdAndIsDeletedFalse(Long memberId);
 
     @Modifying(clearAutomatically = true)
     @Query("update Topic t set t.isDeleted = true where t.id = :topicId")
@@ -37,5 +42,4 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     @Query("update Topic t set t.isDeleted = true where t.creator.id = :memberId")
     void deleteAllByMemberId(@Param("memberId") Long memberId);
 
-    List<Topic> findTopicsByBookmarksMemberId(Long memberId);
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
@@ -1,12 +1,10 @@
 package com.mapbefine.mapbefine.admin.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.mapbefine.mapbefine.atlas.domain.Atlas;
 import com.mapbefine.mapbefine.atlas.domain.AtlasRepository;
-import com.mapbefine.mapbefine.auth.domain.AuthMember;
 import com.mapbefine.mapbefine.bookmark.domain.Bookmark;
 import com.mapbefine.mapbefine.bookmark.domain.BookmarkRepository;
 import com.mapbefine.mapbefine.common.annotation.ServiceTest;
@@ -20,7 +18,6 @@ import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.member.domain.Status;
 import com.mapbefine.mapbefine.permission.domain.Permission;
 import com.mapbefine.mapbefine.permission.domain.PermissionRepository;
-import com.mapbefine.mapbefine.permission.exception.PermissionException.PermissionForbiddenException;
 import com.mapbefine.mapbefine.pin.PinFixture;
 import com.mapbefine.mapbefine.pin.PinImageFixture;
 import com.mapbefine.mapbefine.pin.domain.Pin;

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
@@ -200,14 +200,10 @@ class PinCommandServiceTest {
         pinCommandService.removeById(authMember, pinId);
 
         // then
-        pinRepository.findById(pinId)
-                .ifPresentOrElse(
-                        found -> assertThat(found.isDeleted()).isTrue(),
-                        Assertions::fail
-                );
-        assertThat(pinImageRepository.findAllByPinId(pinId))
-                .extractingResultOf("isDeleted")
-                .containsOnly(true);
+        assertThat(pinRepository.findByIdAndIsDeletedFalse(pinId))
+                .isEmpty();
+        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pinId))
+                .isEmpty();
     }
 
     @Test
@@ -272,11 +268,8 @@ class PinCommandServiceTest {
         pinCommandService.removeImageById(authMember, pinImageId);
 
         // then
-        pinImageRepository.findById(pinImageId)
-                .ifPresentOrElse(
-                        found -> assertThat(found.isDeleted()).isTrue(),
-                        Assertions::fail
-                );
+        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pinImageId))
+                .isEmpty();
     }
 
     private long savePinImageAndGetId(long pinId) {
@@ -290,9 +283,11 @@ class PinCommandServiceTest {
     @Test
     @DisplayName("권한이 없는 토픽의 핀 이미지를 삭제하면 예외를 발생시킨다.")
     void removeImageById_FailByForbidden() {
+        // given
         long pinId = pinCommandService.save(authMember, List.of(BASE_IMAGE_FILE), createRequest);
         long pinImageId = savePinImageAndGetId(pinId);
 
+        // when, then
         assertThatThrownBy(() -> pinCommandService.removeImageById(new Guest(), pinImageId))
                 .isInstanceOf(PinForbiddenException.class);
     }

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
@@ -29,13 +29,14 @@ import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @ServiceTest
 class PinCommandServiceTest {

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinQueryServiceTest.java
@@ -24,12 +24,13 @@ import com.mapbefine.mapbefine.pin.exception.PinException.PinNotFoundException;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @ServiceTest
 class PinQueryServiceTest {
@@ -112,10 +113,15 @@ class PinQueryServiceTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 핀의 Id 를 넘기면 예외를 발생시킨다.")
+    @DisplayName("존재하지 않는 핀의 Id로 조회 시 예외를 발생시킨다. (soft delete 반영)")
     void findDetailById_FailByNonExisting() {
-        // given, when, then
-        assertThatThrownBy(() -> pinQueryService.findDetailById(authMemberUser1, 1L))
+        // given
+        Pin pin = pinRepository.save(PinFixture.create(location, publicUser1Topic, user1));
+        Long softDeletedPin = pin.getId();
+        pinRepository.deleteById(softDeletedPin);
+
+        // when, then
+        assertThatThrownBy(() -> pinQueryService.findDetailById(authMemberUser1, softDeletedPin))
                 .isInstanceOf(PinNotFoundException.class);
     }
 

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinImageRepositoryTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinImageRepositoryTest.java
@@ -14,13 +14,13 @@ import com.mapbefine.mapbefine.pin.PinImageFixture;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import java.util.List;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
 
 @DataJpaTest
 class PinImageRepositoryTest {
@@ -62,11 +62,8 @@ class PinImageRepositoryTest {
         pinImageRepository.deleteById(pinImageId);
 
         //then
-        pinImageRepository.findById(pinImageId)
-                .ifPresentOrElse(
-                        found -> assertThat(found.isDeleted()).isTrue(),
-                        Assertions::fail
-                );
+        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pinImageId))
+                .isEmpty();
     }
 
     @Test
@@ -84,9 +81,8 @@ class PinImageRepositoryTest {
         pinImageRepository.deleteAllByPinId(pin.getId());
 
         //then
-        assertThat(pinImageRepository.findAllByPinId(pin.getId()))
-                .extractingResultOf("isDeleted")
-                .containsOnly(true);
+        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pin.getId()))
+                .isEmpty();
     }
 
     @Test
@@ -103,15 +99,13 @@ class PinImageRepositoryTest {
         //when
         assertThat(pinImage1.isDeleted()).isFalse();
         assertThat(pinImage2.isDeleted()).isFalse();
-        pinImageRepository.deleteAllByPinIds(List.of(pin.getId(),otherPin.getId()));
+        pinImageRepository.deleteAllByPinIds(List.of(pin.getId(), otherPin.getId()));
 
         //then
-        assertThat(pinImageRepository.findAllByPinId(pin.getId()))
-                .extractingResultOf("isDeleted")
-                .containsOnly(true);
-        assertThat(pinImageRepository.findAllByPinId(otherPin.getId()))
-                .extractingResultOf("isDeleted")
-                .containsOnly(true);
+        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pin.getId()))
+                .isEmpty();
+        assertThat(pinImageRepository.findAllByPinIdAndIsDeletedFalse(otherPin.getId()))
+                .isEmpty();
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
@@ -36,7 +36,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 @ServiceTest
 class TopicCommandServiceTest {

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicQueryServiceTest.java
@@ -65,8 +65,25 @@ class TopicQueryServiceTest {
     }
 
     @Test
-    @DisplayName("읽을 수 있는 모든 Topic 목록을 조회한다.")
-    void findAllReadable_Success1() {
+    @DisplayName("비로그인 회원이 읽을 수 있는 모든 Topic 목록을 조회한다.")
+    void findAllReadable_Guest_Success() {
+        //given
+        saveAllReadableTopicOfCount(1);
+        saveOnlyMemberReadableTopicOfCount(10);
+        //when
+        AuthMember guest = new Guest();
+
+        List<TopicResponse> topics = topicQueryService.findAllReadable(guest);
+
+        //then
+        assertThat(topics).hasSize(1);
+        assertThat(topics).extractingResultOf("name")
+                .containsExactlyInAnyOrder("아무나 읽을 수 있는 토픽");
+    }
+
+    @Test
+    @DisplayName("로그인 회원이 읽을 수 있는 모든 Topic 목록을 조회한다.")
+    void findAllReadable_User_Success() {
         //given
         saveAllReadableTopicOfCount(1);
         saveOnlyMemberReadableTopicOfCount(2);
@@ -84,23 +101,6 @@ class TopicQueryServiceTest {
                         "토픽 회원만 읽을 수 있는 토픽",
                         "토픽 회원만 읽을 수 있는 토픽"
                 );
-    }
-
-    @Test
-    @DisplayName("읽을 수 있는 모든 Topic 목록을 조회한다.")
-    void findAllReadable_Success2() {
-        //given
-        saveAllReadableTopicOfCount(1);
-        saveOnlyMemberReadableTopicOfCount(10);
-        //when
-        AuthMember guest = new Guest();
-
-        List<TopicResponse> topics = topicQueryService.findAllReadable(guest);
-
-        //then
-        assertThat(topics).hasSize(1);
-        assertThat(topics).extractingResultOf("name")
-                .containsExactlyInAnyOrder("아무나 읽을 수 있는 토픽");
     }
 
 
@@ -142,6 +142,71 @@ class TopicQueryServiceTest {
         }
     }
 
+    @Test
+    @DisplayName("모든 토픽을 조회할 때, 삭제된 토픽은 볼 수 없다. (soft delete 반영)")
+    void findAllReadable_WithoutSoftDeleted_Success() {
+        //given
+        Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
+        Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
+        topicRepository.save(topic1);
+        topicRepository.save(topic2);
+        topicRepository.deleteById(topic2.getId());
+
+        //when //then
+        AuthMember guest = new Guest();
+        List<TopicResponse> topics = topicQueryService.findAllReadable(guest);
+
+        assertThat(topics).hasSize(1);
+        assertThat(topics).extractingResultOf("id")
+                .containsExactlyInAnyOrder(topic1.getId());
+    }
+
+    @Test
+    @DisplayName("모든 토픽을 조회할 때, 즐겨찾기 여부를 함께 반환한다.")
+    void findAllReadableWithBookmark_Success() {
+        //given
+        Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
+        Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
+        topicRepository.save(topic1);
+        topicRepository.save(topic2);
+
+        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic1, member);
+        bookmarkRepository.save(bookmark);
+
+        //when then
+        AuthMember user = MemberFixture.createUser(member);
+        List<TopicResponse> topics = topicQueryService.findAllReadable(user);
+
+        assertThat(topics).hasSize(2);
+        assertThat(topics).extractingResultOf("id")
+                .containsExactlyInAnyOrder(topic1.getId(), topic2.getId());
+        assertThat(topics).extractingResultOf("isBookmarked")
+                .containsExactlyInAnyOrder(Boolean.FALSE, Boolean.TRUE);
+    }
+
+    @Test
+    @DisplayName("모든 토픽을 조회할 때, 로그인 회원이 아니면 즐겨찾기 여부가 항상 False다")
+    void findAllReadableWithoutBookmark_Success() {
+        //given
+        Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
+        Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
+        topicRepository.save(topic1);
+        topicRepository.save(topic2);
+
+        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic1, member);
+        bookmarkRepository.save(bookmark);
+
+        //when //then
+        AuthMember guest = new Guest();
+        List<TopicResponse> topics = topicQueryService.findAllReadable(guest);
+
+        assertThat(topics).hasSize(2);
+        assertThat(topics).extractingResultOf("id")
+                .containsExactlyInAnyOrder(topic1.getId(), topic2.getId());
+        assertThat(topics).extractingResultOf("isBookmarked")
+                .containsExactlyInAnyOrder(Boolean.FALSE, Boolean.FALSE);
+    }
+    
     @Test
     @DisplayName("권한이 있는 토픽을 ID로 조회한다.")
     void findDetailById_Success() {
@@ -196,8 +261,62 @@ class TopicQueryServiceTest {
     }
 
     @Test
-    @DisplayName("권한이 있는 토픽을 여러개의 ID로 조회한다.")
-    void findDetailByIds_Success1() {
+    @DisplayName("토픽 상세조회시, 삭제된 토픽은 볼 수 없다. (soft delete 반영)")
+    void findDetailById_WithOutSoftDeleted_Success() {
+        //given
+        Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
+        topicRepository.save(topic);
+        topicRepository.deleteById(topic.getId());
+
+        //when then
+        AuthMember user = MemberFixture.createUser(member);
+        assertThatThrownBy(() -> topicQueryService.findDetailById(user, topic.getId()))
+                .isInstanceOf(TopicNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("토픽 상세조회시, 즐겨찾기 여부, 모아보기 여부, 수정 권한 여부를 함께 반환한다.")
+    void findDetailById_WithBookmarkStatus_Success() {
+        //given
+        Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
+        topicRepository.save(topic);
+
+        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic, member);
+        bookmarkRepository.save(bookmark);
+
+        //when then
+        AuthMember user = MemberFixture.createUser(member);
+        TopicDetailResponse topicDetail = topicQueryService.findDetailById(user, topic.getId());
+
+        assertThat(topicDetail.id()).isEqualTo(topic.getId());
+        assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.TRUE);
+        assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
+        assertThat(topicDetail.canUpdate()).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    @DisplayName("토픽 상세조회시, 로그인 회원이 아니라면 즐겨찾기 여부, 모아보기 여부, 수정 권한 여부가 항상 False다.")
+    void findDetailById_WithoutBookmarkStatus_Success() {
+        //given
+        Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
+        topicRepository.save(topic);
+
+        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic, member);
+        bookmarkRepository.save(bookmark);
+
+        //when then
+        AuthMember guest = new Guest();
+        TopicDetailResponse topicDetail = topicQueryService.findDetailById(guest, topic.getId());
+
+        assertThat(topicDetail.id()).isEqualTo(topic.getId());
+        assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.FALSE);
+        assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
+        assertThat(topicDetail.canUpdate()).isEqualTo(Boolean.FALSE);
+    }
+
+    @Test
+    @DisplayName("비로그인 회원이 권한이 있는 토픽을 여러개의 ID로 조회할 수 있다.")
+    void findDetailsByIds_Guest_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -220,8 +339,8 @@ class TopicQueryServiceTest {
     }
 
     @Test
-    @DisplayName("권한이 있는 토픽을 여러개의 ID로 조회한다.")
-    void findDetailByIds_Success2() {
+    @DisplayName("로그인 회원이 권한이 있는 토픽을 여러개의 ID로 조회할 수 있다.")
+    void findDetailsByIds_User_Success() {
         //given
         Topic topic1 = TopicFixture.createPrivateAndGroupOnlyTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -245,7 +364,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("권한이 없는 토픽을 여러개의 ID로 조회하면, 예외가 발생한다.")
-    void findDetailByIds_Fail1() {
+    void findDetailsByIds_FailByForbidden() {
         //given
         Topic topic1 = TopicFixture.createPrivateAndGroupOnlyTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -263,7 +382,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("조회하려는 토픽 중 존재하지 않는 ID가 존재하면, 예외가 발생한다. (soft delete 반영)")
-    void findDetailByIds_Fail2() {
+    void findDetailsByIds_FailByNotFound() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -281,94 +400,8 @@ class TopicQueryServiceTest {
     }
 
     @Test
-    @DisplayName("모든 토픽을 조회할 때, 즐겨찾기 여부를 함께 반환한다.")
-    void findAllReadableWithBookmark_Success() {
-        //given
-        Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
-        Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
-        topicRepository.save(topic1);
-        topicRepository.save(topic2);
-
-        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic1, member);
-        bookmarkRepository.save(bookmark);
-
-        //when then
-        AuthMember user = MemberFixture.createUser(member);
-        List<TopicResponse> topics = topicQueryService.findAllReadable(user);
-
-        assertThat(topics).hasSize(2);
-        assertThat(topics).extractingResultOf("id")
-                .containsExactlyInAnyOrder(topic1.getId(), topic2.getId());
-        assertThat(topics).extractingResultOf("isBookmarked")
-                .containsExactlyInAnyOrder(Boolean.FALSE, Boolean.TRUE);
-    }
-
-    @Test
-    @DisplayName("모든 토픽을 조회할 때, 로그인 회원이 아니면 즐겨찾기 여부가 항상 False다")
-    void findAllReadableWithoutBookmark_Success() {
-        //given
-        Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
-        Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
-        topicRepository.save(topic1);
-        topicRepository.save(topic2);
-
-        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic1, member);
-        bookmarkRepository.save(bookmark);
-
-        //when //then
-        AuthMember guest = new Guest();
-        List<TopicResponse> topics = topicQueryService.findAllReadable(guest);
-
-        assertThat(topics).hasSize(2);
-        assertThat(topics).extractingResultOf("id")
-                .containsExactlyInAnyOrder(topic1.getId(), topic2.getId());
-        assertThat(topics).extractingResultOf("isBookmarked")
-                .containsExactlyInAnyOrder(Boolean.FALSE, Boolean.FALSE);
-    }
-
-    @Test
-    @DisplayName("토픽 상세조회시, 즐겨찾기 여부, 모아보기 여부, 수정 권한 여부를 함께 반환한다.")
-    void findWithBookmarkStatus_Success() {
-        //given
-        Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
-        topicRepository.save(topic);
-
-        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic, member);
-        bookmarkRepository.save(bookmark);
-
-        //when then
-        AuthMember user = MemberFixture.createUser(member);
-        TopicDetailResponse topicDetail = topicQueryService.findDetailById(user, topic.getId());
-
-        assertThat(topicDetail.id()).isEqualTo(topic.getId());
-        assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.TRUE);
-        assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
-        assertThat(topicDetail.canUpdate()).isEqualTo(Boolean.TRUE);
-    }
-
-    @Test
-    @DisplayName("토픽 상세조회시, 로그인 회원이 아니라면 즐겨찾기 여부, 모아보기 여부, 수정 권한 여부가 항상 False다.")
-    void findWithoutBookmarkStatus_Success() {
-        //given
-        Topic topic = TopicFixture.createPublicAndAllMembersTopic(member);
-        topicRepository.save(topic);
-
-        Bookmark bookmark = Bookmark.createWithAssociatedTopicAndMember(topic, member);
-        bookmarkRepository.save(bookmark);
-
-        //when then
-        AuthMember guest = new Guest();
-        TopicDetailResponse topicDetail = topicQueryService.findDetailById(guest, topic.getId());
-
-        assertThat(topicDetail.id()).isEqualTo(topic.getId());
-        assertThat(topicDetail.isBookmarked()).isEqualTo(Boolean.FALSE);
-        assertThat(topicDetail.isInAtlas()).isEqualTo(Boolean.FALSE);
-        assertThat(topicDetail.canUpdate()).isEqualTo(Boolean.FALSE);
-    }
-
-    @Test
     @DisplayName("여러 토픽 조회시, 즐겨 찾기 여부를 함께 반환한다.")
-    void findDetailsWithBookmarkStatus_Success() {
+    void findDetailsByIds_WithBookmarkStatus_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);
@@ -392,7 +425,7 @@ class TopicQueryServiceTest {
 
     @Test
     @DisplayName("여러 토픽 조회시, 로그인 회원이 아니라면 즐겨 찾기 여부가 항상 False다.")
-    void findDetailsWithoutBookmarkStatus_Success() {
+    void findDetailsByIds_WithoutBookmarkStatus_Success() {
         //given
         Topic topic1 = TopicFixture.createPublicAndAllMembersTopic(member);
         Topic topic2 = TopicFixture.createPublicAndAllMembersTopic(member);

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicRepositoryTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicRepositoryTest.java
@@ -7,12 +7,13 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.topic.TopicFixture;
-import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
 
 @DataJpaTest
 class TopicRepositoryTest {


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
- Topic, Pin, PinImage (Soft delete 대상 도메인)

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 엔티티에 일괄 적용하여 통일성을 부여하는 대신, 테스트 코드의 적은 변경사항을 위해 Repository 메서드를 수정하였습니다.
- 조회 시 isDeletedFalse 인 레코드만 가져오도록 Repository 메서드를 수정합니다.
- 테스트에서 사용하는 조회 메서드는 그대로 유지합니다. (테스트에서도 isDeletedFalse로 가져오는 게 로직 상 더 나은 일부 경우,  수정하였음)
- XXXQueryServiceTest에 해당 내용 테스트를 추가했습니다. Topic 다건 조회의 경우 비슷한 로직의 테스트가 많아 모아보기, 전체조회 하는 메서드에 대해서만 우선 테스트 작성했습니다.


## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
운영 서버에 빠른 반영이 필요한 사안이라 main 의 hotfix로 올립니다.  
이 PR 이후 develop-BE-2 브랜치는 main pull 땡겨오고 작업하면 좋을 것 같아요

추가로 mutlipleBag 발생 문제로 인해 Topic의 findByIdAndIsDeletedFalse 조인 항목 중 bookmarks를 삭제했습니다.
## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
closed #473

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
