### PR TITLE
[FE] Fix/#522 토픽 조회 중복 요청 오류, 핀 조회 시 토픽 조회 요청 오류 및 지도 줌인 오류 수정

### DIFF
--- a/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
+++ b/frontend/src/components/TopicInfo/UpdatedTopicInfo.tsx
@@ -19,6 +19,7 @@ interface UpdatedTopicInfoProp {
   name: string;
   description: string;
   setIsUpdate: React.Dispatch<React.SetStateAction<boolean>>;
+  setTopicsFromServer: () => void;
 }
 
 interface FormValues {
@@ -32,6 +33,7 @@ const UpdatedTopicInfo = ({
   name,
   description,
   setIsUpdate,
+  setTopicsFromServer,
 }: UpdatedTopicInfoProp) => {
   const { fetchPost } = usePost();
   const { fetchGet } = useGet();
@@ -78,6 +80,7 @@ const UpdatedTopicInfo = ({
 
       showToast('info', '지도를 수정하였습니다.');
       setIsUpdate(false);
+      setTopicsFromServer();
     } catch {}
   };
 

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -15,7 +15,7 @@ import AddSeeTogether from '../AddSeeTogether';
 import AddFavorite from '../AddFavorite';
 import { styled } from 'styled-components';
 import Box from '../common/Box';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import UpdatedTopicInfo from './UpdatedTopicInfo';
 
 export interface TopicInfoProps {
@@ -66,10 +66,6 @@ const TopicInfo = ({
     }
   };
 
-  useEffect(() => {
-    if (!isUpdate) setTopicsFromServer();
-  }, [isUpdate]);
-
   if (isUpdate) {
     return (
       <UpdatedTopicInfo
@@ -78,6 +74,7 @@ const TopicInfo = ({
         name={topicTitle}
         description={topicDescription}
         setIsUpdate={setIsUpdate}
+        setTopicsFromServer={setTopicsFromServer}
       />
     );
   }

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -63,7 +63,7 @@ const MarkerProvider = ({ children }: Props): JSX.Element => {
         clickedCoordinate.latitude,
         clickedCoordinate.longitude,
       ),
-      icon: 'http://tmapapi.sktelecom.com/upload/tmap/marker/pin_g_m_a.png',
+      icon: 'http://tmapapi.sktelecom.com/upload/tmap/marker/pin_g_m_m.png',
       map,
     });
     marker.id = 'clickedMarker';

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -105,8 +105,9 @@ const MarkerProvider = ({ children }: Props): JSX.Element => {
 
       const infoWindow = new Tmapv3.InfoWindow({
         position: new Tmapv3.LatLng(coordinate.latitude, coordinate.longitude),
-
-        content: `<div style="padding: 4px 12px; display:flex; justify-contents: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${
+        border: 0,
+        background: 'transparent',
+        content: `<div style="padding: 4px 12px; display:flex; border-radius: 20px; justify-contents: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${
           pinColors[markerType + 1]
         };" >${coordinate.pinName}</div>`,
         offset: new Tmapv3.Point(0, -60),

--- a/frontend/src/hooks/useAnimateClickedPin.ts
+++ b/frontend/src/hooks/useAnimateClickedPin.ts
@@ -1,18 +1,19 @@
 import { useEffect } from 'react';
 
 const useAnimateClickedPin = (map: TMap | null, markers: Marker[]) => {
+  const queryParams = new URLSearchParams(location.search);
+
   useEffect(() => {
-    const queryParams = new URLSearchParams(location.search);
     if (queryParams.has('pinDetail')) {
       const pinId = queryParams.get('pinDetail');
-
       const marker = markers.find((marker: Marker) => marker.id === pinId);
+
       if (marker && map) {
         map.setCenter(marker.getPosition());
         map.setZoom(17);
       }
     }
-  }, [markers, map]);
+  }, [markers, map, queryParams]);
 };
 
 export default useAnimateClickedPin;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -14,6 +14,8 @@ const TopicListContainer = lazy(
 );
 
 const Home = () => {
+  console.log(process.env.APP_URL);
+
   const { routingHandlers } = useNavigator();
   const { goToPopularTopics, goToLatestTopics, goToNearByMeTopics } =
     routingHandlers;

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -85,8 +85,6 @@ const SelectedTopic = () => {
   };
 
   useEffect(() => {
-    getAndSetDataFromServer();
-
     const queryParams = new URLSearchParams(location.search);
     if (queryParams.has('pinDetail')) {
       setSelectedPinId(Number(queryParams.get('pinDetail')));
@@ -98,6 +96,7 @@ const SelectedTopic = () => {
   }, [searchParams]);
 
   useEffect(() => {
+    getAndSetDataFromServer();
     setTags([]);
   }, []);
 
@@ -146,7 +145,6 @@ const SelectedTopic = () => {
           <PinDetailWrapper className={isOpen ? '' : 'collapsedPinDetail'}>
             <PinDetail
               width={width}
-              topicId={topicId}
               pinId={selectedPinId}
               isEditPinDetail={isEditPinDetail}
               setIsEditPinDetail={setIsEditPinDetail}

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { ProvidePlugin, EnvironmentPlugin } = require('webpack');
+const { ProvidePlugin, DefinePlugin } = require('webpack');
 const Dotenv = require('dotenv-webpack');
 
 module.exports = {
@@ -21,7 +21,9 @@ module.exports = {
       process: 'process/browser.js',
     }),
 
-    new Dotenv(),
+    new DefinePlugin({
+      'process.env.APP_URL': JSON.stringify(process.env.APP_URL),
+    }),
   ],
   resolve: {
     extensions: ['.tsx', '.ts', '.jsx', '.js'],


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
* 단일, 다중 토픽 조회 시 GET 요청을 두 번 보내던 오류를 수정한다.
* 핀, 핀프리뷰 클릭하여 핀 상세 정보 요청시 토픽 조회 GET 요청을 지속해서 보내는 오류를 수정한다.
* 핀, 핀프리뷰 클릭 시 지도 줌인이 되지 않는 오류를 수정한다.
* 핀 infoWindow 디자인을 변경한다.

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] 단일, 다중 토픽 조회 시 GET 요청을 두 번 보내던 오류를 수정한다.
- [x] 핀, 핀프리뷰 클릭하여 핀 상세 정보 요청시 토픽 조회 GET 요청을 지속해서 보내는 오류를 수정한다.
- [x] 핀, 핀프리뷰 클릭 시 지도 줌인이 되지 않는 오류를 수정한다.
- [x] 핀 infoWindow 디자인을 변경한다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
API env 테스트 console 있습니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
close #522 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
