### PR TITLE
[FE] design: 반응형 사이즈에서 로고 영역 배경 투명하게 적용

### DIFF
--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -95,8 +95,8 @@ const LogoWrapper = styled.section<{
     ${({ $layoutWidth }) =>
       $layoutWidth === '372px' &&
       css`
-        width: 100vw;
-        background-color: white;
+        width: max-content;
+        background-color: transparent;
         position: fixed;
         top: 0;
         z-index: 1;


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
* 반응형 사이즈에서 지도 조회 페이지

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
* 반응형 사이즈에서 로고 영역 배경을 투명하게 하여 지도를 보다 더 넓게 볼 수 있도록 합니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->
![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/0d61521e-c5d4-4dae-a102-6b594abe96e2)


## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
