### PR TITLE
[BE] Hotfix/#537,#538 회원 정보 관련 이슈 해결

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/AuthMember.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/AuthMember.java
@@ -1,8 +1,8 @@
 package com.mapbefine.mapbefine.auth.domain;
 
-import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import java.util.List;
+import java.util.Objects;
 
 public abstract class AuthMember {
 
@@ -27,11 +27,13 @@ public abstract class AuthMember {
     public abstract boolean canTopicUpdate(Topic topic);
 
     public abstract boolean canPinCreateOrUpdate(Topic topic);
-
-    public abstract boolean isRole(Role role);
-
+    
     public Long getMemberId() {
         return memberId;
+    }
+
+    public boolean isSameMember(Long memberId) {
+        return Objects.equals(memberId, this.memberId);
     }
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/member/Admin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/member/Admin.java
@@ -1,7 +1,6 @@
 package com.mapbefine.mapbefine.auth.domain.member;
 
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
-import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import java.util.Collections;
 
@@ -33,11 +32,6 @@ public class Admin extends AuthMember {
     @Override
     public boolean canPinCreateOrUpdate(Topic topic) {
         return true;
-    }
-
-    @Override
-    public boolean isRole(Role role) {
-        return Role.ADMIN == role;
     }
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/member/Guest.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/member/Guest.java
@@ -1,7 +1,6 @@
 package com.mapbefine.mapbefine.auth.domain.member;
 
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
-import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicStatus;
 import java.util.Collections;
@@ -37,8 +36,4 @@ public class Guest extends AuthMember {
         return false;
     }
 
-    @Override
-    public boolean isRole(Role role) {
-        return Role.GUEST == role;
-    }
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/member/User.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/auth/domain/member/User.java
@@ -1,7 +1,6 @@
 package com.mapbefine.mapbefine.auth.domain.member;
 
 import com.mapbefine.mapbefine.auth.domain.AuthMember;
-import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicStatus;
 import java.util.List;
@@ -53,11 +52,6 @@ public class User extends AuthMember {
 
     private boolean hasPermission(Long topicId) {
         return createdTopic.contains(topicId) || topicsWithPermission.contains(topicId);
-    }
-
-    @Override
-    public boolean isRole(Role role) {
-        return Role.USER == role;
     }
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/common/interceptor/AuthInterceptor.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/common/interceptor/AuthInterceptor.java
@@ -40,7 +40,7 @@ public class AuthInterceptor implements HandlerInterceptor {
         if (!(handler instanceof HandlerMethod handlerMethod)) {
             return true;
         }
-        if (isAuthMemberNotRequired(handlerMethod)) {
+        if (isAuthMemberNotRequired(handlerMethod) && isLoginNotRequired(handlerMethod)) {
             return true;
         }
 
@@ -58,6 +58,10 @@ public class AuthInterceptor implements HandlerInterceptor {
     private boolean isAuthMemberNotRequired(HandlerMethod handlerMethod) {
         return Arrays.stream(handlerMethod.getMethodParameters())
                 .noneMatch(parameter -> parameter.getParameterType().equals(AuthMember.class));
+    }
+
+    private boolean isLoginNotRequired(HandlerMethod handlerMethod) {
+        return !isLoginRequired(handlerMethod);
     }
 
     private boolean isLoginRequired(HandlerMethod handlerMethod) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
@@ -14,10 +14,9 @@ import com.mapbefine.mapbefine.pin.dto.response.PinResponse;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -49,13 +48,14 @@ public class MemberQueryService {
 
     private Member findMemberById(Long id) {
         return memberRepository.findById(id)
+                .filter(Member::isNormalStatus)
                 .orElseThrow(() -> new MemberNotFoundException(MemberErrorCode.MEMBER_NOT_FOUND, id));
     }
 
-    // TODO: 2023/09/13 차단된 or 탈퇴한 사용자 필터링 필요
     public List<MemberResponse> findAll() {
         return memberRepository.findAll()
                 .stream()
+                .filter(Member::isNormalStatus)
                 .map(MemberResponse::from)
                 .toList();
     }
@@ -63,7 +63,8 @@ public class MemberQueryService {
     public List<TopicResponse> findAllTopicsInBookmark(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> bookMarkedTopics = topicRepository.findTopicsByBookmarksMemberIdAndIsDeletedFalse(authMember.getMemberId());
+        List<Topic> bookMarkedTopics = topicRepository.findTopicsByBookmarksMemberIdAndIsDeletedFalse(
+                authMember.getMemberId());
         return bookMarkedTopics.stream()
                 .map(topic -> TopicResponse.from(
                         topic,

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
@@ -9,6 +9,7 @@ import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.member.dto.response.MemberDetailResponse;
 import com.mapbefine.mapbefine.member.dto.response.MemberResponse;
 import com.mapbefine.mapbefine.member.exception.MemberErrorCode;
+import com.mapbefine.mapbefine.member.exception.MemberException.MemberForbiddenException;
 import com.mapbefine.mapbefine.member.exception.MemberException.MemberNotFoundException;
 import com.mapbefine.mapbefine.pin.dto.response.PinResponse;
 import com.mapbefine.mapbefine.topic.domain.Topic;
@@ -40,10 +41,12 @@ public class MemberQueryService {
         this.topicRepository = topicRepository;
     }
 
-    public MemberDetailResponse findById(Long id) {
-        Member member = findMemberById(id);
-
-        return MemberDetailResponse.from(member);
+    public MemberDetailResponse findById(AuthMember authMember, Long id) {
+        if (authMember.isSameMember(id)) {
+            Member member = findMemberById(id);
+            return MemberDetailResponse.from(member);
+        }
+        throw new MemberForbiddenException(MemberErrorCode.FORBIDDEN_ACCESS, id);
     }
 
     private Member findMemberById(Long id) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/dto/response/MemberResponse.java
@@ -3,10 +3,9 @@ package com.mapbefine.mapbefine.member.dto.response;
 import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberInfo;
 
-public record MemberResponse (
+public record MemberResponse(
         Long id,
-        String nickName,
-        String email
+        String nickName
 ) {
 
     public static MemberResponse from(Member member) {
@@ -14,8 +13,7 @@ public record MemberResponse (
 
         return new MemberResponse(
                 member.getId(),
-                memberInfo.getNickName(),
-                memberInfo.getEmail()
+                memberInfo.getNickName()
         );
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/exception/MemberErrorCode.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/exception/MemberErrorCode.java
@@ -10,6 +10,7 @@ public enum MemberErrorCode {
     ILLEGAL_EMAIL_NULL("05002", "이메일은 필수로 입력해야합니다."),
     ILLEGAL_EMAIL_PATTERN("05003", "올바르지 않은 이메일 형식입니다."),
     FORBIDDEN_MEMBER_STATUS("05100", "탈퇴 혹은 차단된 회원입니다."),
+    FORBIDDEN_ACCESS("05101", "해당 회원 정보에 대한 접근 권한이 없습니다."),
     MEMBER_NOT_FOUND("05400", "존재하지 않는 회원입니다."),
     ILLEGAL_NICKNAME_ALREADY_EXISTS("05900", "이미 존재하는 닉네임입니다."),
     ;

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/presentation/MemberController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/presentation/MemberController.java
@@ -40,8 +40,8 @@ public class MemberController {
 
     @LoginRequired
     @GetMapping("/{memberId}")
-    public ResponseEntity<MemberDetailResponse> findMemberById(@PathVariable Long memberId) {
-        MemberDetailResponse response = memberQueryService.findById(memberId);
+    public ResponseEntity<MemberDetailResponse> findMemberById(AuthMember authMember, @PathVariable Long memberId) {
+        MemberDetailResponse response = memberQueryService.findById(authMember, memberId);
 
         return ResponseEntity.ok(response);
     }

--- a/backend/src/main/resources/data-default.sql
+++ b/backend/src/main/resources/data-default.sql
@@ -5,7 +5,7 @@ VALUES ('dummyMember', 'dummy@gmail.com', 'https://map-befine-official.github.io
         1L, 'KAKAO',
         now(), now());
 
-INSERT INTO topic (name, image_url, description,가
+INSERT INTO topic (name, image_url, description,
                    permission_type, publicity,
                    member_id,
                    created_at, updated_at, last_pin_updated_at)

--- a/backend/src/test/java/com/mapbefine/mapbefine/member/domain/MemberResponseTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/member/domain/MemberResponseTest.java
@@ -25,8 +25,6 @@ class MemberResponseTest {
         // then
         assertThat(memberResponse.nickName())
                 .isEqualTo(member.getMemberInfo().getNickName());
-        assertThat(memberResponse.email())
-                .isEqualTo(member.getMemberInfo().getEmail());
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/member/presentation/MemberControllerTest.java
@@ -58,7 +58,7 @@ class MemberControllerTest extends RestDocsIntegration {
                 LocalDateTime.now()
         );
 
-        given(memberQueryService.findById(any())).willReturn(memberDetailResponse);
+        given(memberQueryService.findById(any(), any())).willReturn(memberDetailResponse);
 
         mockMvc.perform(
                 MockMvcRequestBuilders.get("/members/1")

--- a/backend/src/test/java/com/mapbefine/mapbefine/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/member/presentation/MemberControllerTest.java
@@ -31,13 +31,11 @@ class MemberControllerTest extends RestDocsIntegration {
         List<MemberResponse> memberResponses = List.of(
                 new MemberResponse(
                         1L,
-                        "member1",
-                        "member1@member.com"
+                        "member1"
                 ),
                 new MemberResponse(
                         2L,
-                        "member2",
-                        "member2@member.com"
+                        "member2"
                 )
         );
 

--- a/backend/src/test/java/com/mapbefine/mapbefine/permission/presentation/PermissionControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/permission/presentation/PermissionControllerTest.java
@@ -52,8 +52,8 @@ class PermissionControllerTest extends RestDocsIntegration {
     @DisplayName("특정 토픽 접근 정보 조회(권한 회원 목록, 공개 여부)")
     void findTopicAccessDetailByTopicId() throws Exception {
         List<PermissionedMemberResponse> permissionedMembers = List.of(
-                new PermissionedMemberResponse(1L, new MemberResponse(1L, "member", "member@naver.com")),
-                new PermissionedMemberResponse(1L, new MemberResponse(2L, "memberr", "memberr@naver.com"))
+                new PermissionedMemberResponse(1L, new MemberResponse(1L, "member")),
+                new PermissionedMemberResponse(1L, new MemberResponse(2L, "memberr"))
         );
         TopicAccessDetailResponse response = new TopicAccessDetailResponse(Publicity.PUBLIC, permissionedMembers);
 


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
- #537
- #538
에 대한 이슈 해결 PR입니다.

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- #537, #538 해결
    - Interceptor, ArgumentResolver 관련 리팩터링 추후 진행 예정
- 회원 상세 조회 시 자기 자신만 조회 가능하도록 수정
    - API 명세 추후 변경 예정
- **추가로 (관리자 API가 아닌) 회원 조회 시 stream.filter로 Member.isNormalStatus 인 경우만 조회하도록 했습니다.**
    - 쿼리 where절에 거는 방법도 있을텐데 이 부분은 머지 후 추가로 의견 나눠보면 좋을 것 같습니다!

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
closed #537 #538

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
