### PR TITLE
[BE] Refactor/#540 지연로딩의 경우, soft delete을 반영할 수 없는 문제 해결

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
@@ -16,8 +16,6 @@ import com.mapbefine.mapbefine.pin.exception.PinException.PinNotFoundException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.exception.TopicException;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
@@ -27,8 +25,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AdminCommandService {
 
-    @PersistenceContext
-    private EntityManager entityManager;
     private final MemberRepository memberRepository;
     private final TopicRepository topicRepository;
     private final PinRepository pinRepository;
@@ -67,9 +63,11 @@ public class AdminCommandService {
         Long memberId = member.getId();
 
         permissionRepository.deleteAllByMemberId(memberId);
+        permissionRepository.flush();
         atlasRepository.deleteAllByMemberId(memberId);
+        atlasRepository.flush();
         bookmarkRepository.deleteAllByMemberId(memberId);
-        entityManager.flush();
+        bookmarkRepository.flush();
         pinImageRepository.deleteAllByPinIds(pinIds);
         pinRepository.deleteAllByMemberId(memberId);
         topicRepository.deleteAllByMemberId(memberId);

--- a/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
@@ -97,7 +97,7 @@ public class AdminCommandService {
     }
 
     public void deletePin(Long pinId) {
-        Pin pin = pinRepository.findByIdAndIsDeletedFalse(pinId)
+        Pin pin = pinRepository.findById(pinId)
                 .orElseThrow(() -> new PinNotFoundException(PIN_NOT_FOUND, pinId));
 
         /// TODO: 2023/10/05 soft delete를 @Query로 구현하면서, pinCount 반영을 통합할 수 없음

--- a/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
@@ -86,6 +86,7 @@ public class AdminCommandService {
     }
 
     public void deleteTopic(Long topicId) {
+        /// TODO: 2023/10/06 pin, pinImage 삭제
         topicRepository.deleteById(topicId);
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
@@ -106,7 +106,7 @@ public class AdminCommandService {
                 .orElseThrow(() -> new PinNotFoundException(PIN_NOT_FOUND, pinId));
 
         /// TODO: 2023/10/05 soft delete를 @Query로 구현하면서, pinCount 반영을 통합할 수 없음
-        pin.decrementTopicPinCount();
+        pin.decreaseTopicPinCount();
         pinRepository.deleteById(pin.getId());
         /// TODO: 2023/10/05  pinImage는?
     }

--- a/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
@@ -16,6 +16,8 @@ import com.mapbefine.mapbefine.pin.exception.PinException.PinNotFoundException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.exception.TopicException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class AdminCommandService {
 
+    @PersistenceContext
+    private EntityManager entityManager;
     private final MemberRepository memberRepository;
     private final TopicRepository topicRepository;
     private final PinRepository pinRepository;
@@ -62,12 +66,13 @@ public class AdminCommandService {
         List<Long> pinIds = extractPinIdsByMember(member);
         Long memberId = member.getId();
 
-        pinImageRepository.deleteAllByPinIds(pinIds);
-        topicRepository.deleteAllByMemberId(memberId);
-        pinRepository.deleteAllByMemberId(memberId);
         permissionRepository.deleteAllByMemberId(memberId);
         atlasRepository.deleteAllByMemberId(memberId);
         bookmarkRepository.deleteAllByMemberId(memberId);
+        entityManager.flush();
+        pinImageRepository.deleteAllByPinIds(pinIds);
+        pinRepository.deleteAllByMemberId(memberId);
+        topicRepository.deleteAllByMemberId(memberId);
     }
 
     private Member findMemberById(Long id) {
@@ -92,7 +97,7 @@ public class AdminCommandService {
     }
 
     private Topic findTopicById(Long topicId) {
-        return topicRepository.findByIdAndIsDeletedFalse(topicId)
+        return topicRepository.findById(topicId)
                 .orElseThrow(() -> new TopicException.TopicNotFoundException(TOPIC_NOT_FOUND, List.of(topicId)));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/atlas/application/AtlasCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/atlas/application/AtlasCommandService.java
@@ -13,11 +13,10 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -73,7 +72,7 @@ public class AtlasCommandService {
     }
 
     private Topic findTopicById(Long topicId) {
-        return topicRepository.findByIdAndIsDeletedFalse(topicId)
+        return topicRepository.findById(topicId)
                 .orElseThrow(() -> new AtlasBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/atlas/domain/AtlasRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/atlas/domain/AtlasRepository.java
@@ -7,7 +7,10 @@ import org.springframework.stereotype.Repository;
 public interface AtlasRepository extends JpaRepository<Atlas, Long> {
 
     boolean existsByMemberIdAndTopicId(Long memberId, Long topicId);
+
     void deleteByMemberIdAndTopicId(Long memberId, Long topicId);
 
     void deleteAllByMemberId(Long memberId);
+
+    void deleteAllByTopicId(Long topicId);
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/auth/application/AuthService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/auth/application/AuthService.java
@@ -11,7 +11,6 @@ import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +30,7 @@ public class AuthService {
         }
     }
 
+    // TODO 테스트가 필요하긴 한데, MemberQueryService와 너무 중복되는 내용이다. 엔티티 테스트로 중복을 없앨 수 있으면 좋겠다.
     public AuthMember findAuthMemberByMemberId(Long memberId) {
         return memberRepository.findById(memberId)
                 .map(this::convertToAuthMember)
@@ -61,17 +61,6 @@ public class AuthService {
                 .stream()
                 .map(Topic::getId)
                 .toList();
-    }
-
-    public boolean isAdmin(Long memberId) {
-        if (Objects.isNull(memberId)) {
-            return false;
-        }
-
-        Optional<Member> member = memberRepository.findById(memberId);
-
-        return member.map(Member::isAdmin)
-                .orElse(false);
     }
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/auth/application/AuthService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/auth/application/AuthService.java
@@ -30,11 +30,13 @@ public class AuthService {
         }
     }
 
-    // TODO 테스트가 필요하긴 한데, MemberQueryService와 너무 중복되는 내용이다. 엔티티 테스트로 중복을 없앨 수 있으면 좋겠다.
     public AuthMember findAuthMemberByMemberId(Long memberId) {
-        return memberRepository.findById(memberId)
-                .map(this::convertToAuthMember)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("findAuthMemberByMemberId; memberId= " + memberId));
+        if (member.isNormalStatus()) {
+            return convertToAuthMember(member);
+        }
+        throw new AuthUnauthorizedException(AuthErrorCode.ILLEGAL_MEMBER_ID);
     }
 
     private AuthMember convertToAuthMember(Member member) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/bookmark/application/BookmarkCommandService.java
@@ -15,10 +15,9 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
+import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.NoSuchElementException;
 
 @Service
 @Transactional
@@ -53,7 +52,7 @@ public class BookmarkCommandService {
     }
 
     private Topic getTopicById(Long topicId) {
-        return topicRepository.findByIdAndIsDeletedFalse(topicId)
+        return topicRepository.findById(topicId)
                 .orElseThrow(() -> new BookmarkBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/bookmark/domain/BookmarkRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/bookmark/domain/BookmarkRepository.java
@@ -5,10 +5,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
+    Optional<Bookmark> findByMemberIdAndTopicId(Long memberId, Long topicId);
+
     boolean existsByMemberIdAndTopicId(Long memberId, Long topicId);
 
     void deleteAllByMemberId(Long memberId);
 
-    Optional<Bookmark> findByMemberIdAndTopicId(Long memberId, Long topicId);
+    void deleteAllByTopicId(Long topicId);
 
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/bookmark/domain/BookmarkRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/bookmark/domain/BookmarkRepository.java
@@ -1,15 +1,12 @@
 package com.mapbefine.mapbefine.bookmark.domain;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     boolean existsByMemberIdAndTopicId(Long memberId, Long topicId);
 
-    @Modifying(clearAutomatically = true)
     void deleteAllByMemberId(Long memberId);
 
     Optional<Bookmark> findByMemberIdAndTopicId(Long memberId, Long topicId);

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberCommandService.java
@@ -26,7 +26,7 @@ public class MemberCommandService {
 
         validateNicknameDuplicated(nickName);
 
-        member.update(nickName);
+        member.updateNickName(nickName);
     }
 
     private Member findMemberById(Long memberId) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
@@ -66,7 +66,7 @@ public class MemberQueryService {
     public List<TopicResponse> findAllTopicsInBookmark(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        List<Topic> bookMarkedTopics = topicRepository.findTopicsByBookmarksMemberIdAndIsDeletedFalse(
+        List<Topic> bookMarkedTopics = topicRepository.findTopicsByBookmarksMemberId(
                 authMember.getMemberId());
         return bookMarkedTopics.stream()
                 .map(topic -> TopicResponse.from(

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
@@ -90,7 +90,6 @@ public class MemberQueryService {
 
     public List<TopicResponse> findAllTopicsInAtlas(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
-
         List<Topic> topicsInAtlas = findTopicsInAtlas(member);
 
         return topicsInAtlas.stream()
@@ -107,7 +106,6 @@ public class MemberQueryService {
     }
 
     public List<TopicResponse> findMyAllTopics(AuthMember authMember) {
-
         Long memberId = authMember.getMemberId();
         Member member = findMemberById(memberId);
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/domain/Member.java
@@ -104,10 +104,14 @@ public class Member extends BaseTimeEntity {
                 .substring(0, DEFAULT_NICKNAME_SUFFIX_LENGTH);
     }
 
-    public void update(
+    public void updateNickName(
             String nickName
     ) {
         memberInfo = memberInfo.createUpdatedMemberInfo(nickName);
+    }
+
+    public void updateStatus(Status status) {
+        memberInfo = memberInfo.createUpdatedMemberInfo(status);
     }
 
     public void addTopic(Topic topic) {
@@ -146,15 +150,5 @@ public class Member extends BaseTimeEntity {
 
     public boolean isNormalStatus() {
         return memberInfo.getStatus() == Status.NORMAL;
-    }
-
-    public void updateStatus(Status status) {
-        memberInfo = MemberInfo.of(
-                memberInfo.getNickName(),
-                memberInfo.getEmail(),
-                memberInfo.getImageUrl(),
-                memberInfo.getRole(),
-                status
-        );
     }
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/domain/MemberInfo.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/domain/MemberInfo.java
@@ -113,6 +113,11 @@ public class MemberInfo {
         return MemberInfo.of(nickName, this.email, this.imageUrl.getImageUrl(), this.role, this.status);
     }
 
+    public MemberInfo createUpdatedMemberInfo(Status status) {
+
+        return MemberInfo.of(this.nickName, this.email, this.imageUrl.getImageUrl(), this.role, status);
+    }
+
     public String getImageUrl() {
         return imageUrl.getImageUrl();
     }

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionCommandService.java
@@ -15,11 +15,10 @@ import com.mapbefine.mapbefine.permission.exception.PermissionException.Permissi
 import com.mapbefine.mapbefine.permission.exception.PermissionException.PermissionForbiddenException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional
@@ -78,7 +77,7 @@ public class PermissionCommandService {
 
     private Topic findTopic(PermissionRequest request) {
         Long topicId = request.topicId();
-        return topicRepository.findByIdAndIsDeletedFalse(topicId)
+        return topicRepository.findById(topicId)
                 .orElseThrow(() -> new PermissionBadRequestException(ILLEGAL_TOPIC_ID, topicId));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionQueryService.java
@@ -48,6 +48,7 @@ public class PermissionQueryService {
                 .orElseThrow(() -> new TopicNotFoundException(TopicErrorCode.TOPIC_NOT_FOUND, topicId));
     }
 
+    @Deprecated(since = "2023.10.06")
     public PermissionMemberDetailResponse findPermissionById(Long permissionId) {
         Permission permission = permissionRepository.findById(permissionId)
                 .orElseThrow(() -> new PermissionNotFoundException(PERMISSION_NOT_FOUND, permissionId));

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/application/PermissionQueryService.java
@@ -14,10 +14,9 @@ import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.domain.TopicStatus;
 import com.mapbefine.mapbefine.topic.exception.TopicErrorCode;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicNotFoundException;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -43,7 +42,7 @@ public class PermissionQueryService {
     }
 
     private Publicity findTopicPublicityById(Long topicId) {
-        return topicRepository.findByIdAndIsDeletedFalse(topicId)
+        return topicRepository.findById(topicId)
                 .map(Topic::getTopicStatus)
                 .map(TopicStatus::getPublicity)
                 .orElseThrow(() -> new TopicNotFoundException(TopicErrorCode.TOPIC_NOT_FOUND, topicId));

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/domain/PermissionRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/domain/PermissionRepository.java
@@ -11,4 +11,6 @@ public interface PermissionRepository extends JpaRepository<Permission, Long> {
 
     void deleteAllByMemberId(Long memberId);
 
+    void deleteAllByTopicId(Long topicId);
+
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/domain/PermissionRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/domain/PermissionRepository.java
@@ -10,4 +10,5 @@ public interface PermissionRepository extends JpaRepository<Permission, Long> {
     boolean existsByTopicIdAndMemberId(Long topicId, Long memberId);
 
     void deleteAllByMemberId(Long memberId);
+
 }

--- a/backend/src/main/java/com/mapbefine/mapbefine/permission/presentation/PermissionController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/permission/presentation/PermissionController.java
@@ -56,8 +56,7 @@ public class PermissionController {
         return ResponseEntity.ok(response);
     }
 
-    // TODO 이 API를 쓰는 곳이 있나? + 결국 특정 회원을 조회하는 건데 어떤 API인지 알기 어렵다..
-    //  회원 정보 조회는 /members 에서 하는 걸로 충분하지 않나? 재사용성이 떨어진다. 테스트의 DisplayName도 매칭이 안된다.
+    @Deprecated(since = "2023.10.06")
     @LoginRequired
     @GetMapping("/{permissionId}")
     public ResponseEntity<PermissionMemberDetailResponse> findPermissionById(@PathVariable Long permissionId) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
@@ -27,13 +27,12 @@ import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicBadRequestException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @Service
@@ -146,7 +145,7 @@ public class PinCommandService {
     }
 
     private Pin findPin(Long pinId) {
-        return pinRepository.findByIdAndIsDeletedFalse(pinId)
+        return pinRepository.findById(pinId)
                 .orElseThrow(() -> new PinBadRequestException(ILLEGAL_PIN_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
@@ -99,7 +99,7 @@ public class PinCommandService {
         if (Objects.isNull(topicId)) {
             throw new TopicBadRequestException(ILLEGAL_TOPIC_ID);
         }
-        return topicRepository.findByIdAndIsDeletedFalse(topicId)
+        return topicRepository.findById(topicId)
                 .orElseThrow(() -> new TopicBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinCommandService.java
@@ -181,7 +181,7 @@ public class PinCommandService {
     }
 
     private PinImage findPinImage(Long pinImageId) {
-        return pinImageRepository.findByIdAndIsDeletedFalse(pinImageId)
+        return pinImageRepository.findById(pinImageId)
                 .orElseThrow(() -> new PinBadRequestException(ILLEGAL_PIN_IMAGE_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/application/PinQueryService.java
@@ -11,10 +11,9 @@ import com.mapbefine.mapbefine.pin.dto.response.PinResponse;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
 import com.mapbefine.mapbefine.pin.exception.PinException.PinNotFoundException;
 import com.mapbefine.mapbefine.topic.domain.Topic;
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Transactional(readOnly = true)
 @Service
@@ -27,7 +26,7 @@ public class PinQueryService {
     }
 
     public List<PinResponse> findAllReadable(AuthMember member) {
-        return pinRepository.findAllByIsDeletedFalse()
+        return pinRepository.findAll()
                 .stream()
                 .filter(pin -> member.canRead(pin.getTopic()))
                 .map(PinResponse::from)
@@ -35,7 +34,7 @@ public class PinQueryService {
     }
 
     public PinDetailResponse findDetailById(AuthMember member, Long pinId) {
-        Pin pin = pinRepository.findByIdAndIsDeletedFalse(pinId)
+        Pin pin = pinRepository.findById(pinId)
                 .orElseThrow(() -> new PinNotFoundException(PIN_NOT_FOUND, pinId));
         validateReadAuth(member, pin.getTopic());
 
@@ -51,7 +50,7 @@ public class PinQueryService {
     }
 
     public List<PinResponse> findAllPinsByMemberId(AuthMember authMember, Long memberId) {
-        return pinRepository.findAllByCreatorIdAndIsDeletedFalse(memberId)
+        return pinRepository.findAllByCreatorId(memberId)
                 .stream()
                 .filter(pin -> authMember.canRead(pin.getTopic()))
                 .map(PinResponse::from)

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
@@ -24,10 +24,12 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 @Getter
+@Where(clause = "is_deleted = false")
 public class Pin extends BaseTimeEntity {
 
     @Id

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
@@ -104,8 +104,8 @@ public class Pin extends BaseTimeEntity {
         pinInfo = PinInfo.of(name, description);
     }
 
-    public void decrementTopicPinCount() {
-        topic.decrementPinCount();
+    public void decreaseTopicPinCount() {
+        topic.decreasePinCount();
     }
 
     public void copyToTopic(Member creator, Topic topic) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/Pin.java
@@ -104,6 +104,10 @@ public class Pin extends BaseTimeEntity {
         pinInfo = PinInfo.of(name, description);
     }
 
+    public void decrementTopicPinCount() {
+        topic.decrementPinCount();
+    }
+
     public void copyToTopic(Member creator, Topic topic) {
         Pin copiedPin = Pin.createPinAssociatedWithLocationAndTopicAndMember(
                 pinInfo.getName(),

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinImage.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinImage.java
@@ -14,10 +14,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Where(clause = "is_deleted = false")
 public class PinImage extends BaseTimeEntity {
 
     @Id

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinImageRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinImageRepository.java
@@ -1,20 +1,19 @@
 package com.mapbefine.mapbefine.pin.domain;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface PinImageRepository extends JpaRepository<PinImage, Long> {
 
-    Optional<PinImage> findByIdAndIsDeletedFalse(Long pinId);
+    Optional<PinImage> findById(Long pinId);
 
-    List<PinImage> findAllByPinIdAndIsDeletedFalse(Long pinId);
+    List<PinImage> findAllByPinId(Long pinId);
 
     @Modifying(clearAutomatically = true)
     @Query("update PinImage p set p.isDeleted = true where p.pin.id = :pinId")

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/domain/PinRepository.java
@@ -1,5 +1,6 @@
 package com.mapbefine.mapbefine.pin.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -7,22 +8,14 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface PinRepository extends JpaRepository<Pin, Long> {
 
     @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
-    List<Pin> findAllByIsDeletedFalse();
-
-    Optional<Pin> findByIdAndIsDeletedFalse(Long pinId);
+    List<Pin> findAll();
 
     @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
     List<Pin> findAllByTopicId(Long topicId);
-
-    @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
-    List<Pin> findAllByCreatorIdAndIsDeletedFalse(Long creatorId);
 
     @EntityGraph(attributePaths = {"location", "topic", "creator", "pinImages"})
     List<Pin> findAllByCreatorId(Long creatorId);

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -238,8 +238,8 @@ public class TopicCommandService {
 
         validateDeleteAuth(member, topic);
 
+        /// TODO: 2023/10/06 PinImage 삭제
         pinRepository.deleteAllByTopicId(topicId);
-        /// TODO: 2023/10/05  topic의 pinCount는?
         topicRepository.deleteById(topicId);
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -234,16 +234,17 @@ public class TopicCommandService {
         throw new TopicForbiddenException(FORBIDDEN_TOPIC_UPDATE);
     }
 
+    @Deprecated(since = "2023.10.06")
     public void delete(AuthMember member, Long topicId) {
         Topic topic = findTopic(topicId);
-
         validateDeleteAuth(member, topic);
 
-        /// TODO: 2023/10/06 PinImage 삭제
+        /// TODO: 2023/10/06 연관관계 다 삭제해야 하는데, 관리자 API와 중복 로직이며 관리자 API에서만 사용됨
         pinRepository.deleteAllByTopicId(topicId);
         topicRepository.deleteById(topicId);
     }
 
+    @Deprecated(since = "2023.10.06")
     private void validateDeleteAuth(AuthMember member, Topic topic) {
         if (member.canDelete(topic)) {
             return;

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -160,7 +160,7 @@ public class TopicCommandService {
     }
 
     private List<Topic> findAllTopics(List<Long> topicIds) {
-        List<Topic> findTopics = topicRepository.findByIdInAndIsDeletedFalse(topicIds);
+        List<Topic> findTopics = topicRepository.findByIdIn(topicIds);
 
         if (topicIds.size() != findTopics.size()) {
             throw new TopicBadRequestException(ILLEGAL_TOPIC_ID);
@@ -196,7 +196,7 @@ public class TopicCommandService {
     }
 
     private Topic findTopic(Long topicId) {
-        return topicRepository.findByIdAndIsDeletedFalse(topicId)
+        return topicRepository.findById(topicId)
                 .orElseThrow(() -> new TopicBadRequestException(ILLEGAL_TOPIC_ID));
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -94,7 +94,8 @@ public class TopicCommandService {
 
         return memberRepository.findById(memberId)
                 .orElseThrow(
-                        () -> new NoSuchElementException("findCreatorByAuthMember; member not found; id=" + memberId));
+                        () -> new NoSuchElementException("findCreatorByAuthMember; member not found; id=" + memberId)
+                );
     }
 
     private void copyPinsToTopic(

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicCommandService.java
@@ -22,14 +22,13 @@ import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequest;
 import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicBadRequestException;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicForbiddenException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Transactional
 @Service
@@ -94,7 +93,8 @@ public class TopicCommandService {
         }
 
         return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NoSuchElementException("findCreatorByAuthMember; member not found; id=" + memberId));
+                .orElseThrow(
+                        () -> new NoSuchElementException("findCreatorByAuthMember; member not found; id=" + memberId));
     }
 
     private void copyPinsToTopic(
@@ -239,6 +239,7 @@ public class TopicCommandService {
         validateDeleteAuth(member, topic);
 
         pinRepository.deleteAllByTopicId(topicId);
+        /// TODO: 2023/10/05  topic의 pinCount는?
         topicRepository.deleteById(topicId);
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/application/TopicQueryService.java
@@ -14,13 +14,12 @@ import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicForbiddenException;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicNotFoundException;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
@@ -51,7 +50,7 @@ public class TopicQueryService {
     }
 
     private List<TopicResponse> getGuestTopicResponses(AuthMember authMember) {
-        return topicRepository.findAllByIsDeletedFalse()
+        return topicRepository.findAll()
                 .stream()
                 .filter(authMember::canRead)
                 .map(TopicResponse::fromGuestQuery)
@@ -61,7 +60,7 @@ public class TopicQueryService {
     private List<TopicResponse> getUserTopicResponses(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAllByIsDeletedFalse().stream()
+        return topicRepository.findAll().stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
                         topic,
@@ -103,7 +102,7 @@ public class TopicQueryService {
     }
 
     private Topic findTopic(Long id) {
-        return topicRepository.findByIdAndIsDeletedFalse(id)
+        return topicRepository.findById(id)
                 .orElseThrow(() -> new TopicNotFoundException(TOPIC_NOT_FOUND, List.of(id)));
     }
 
@@ -116,7 +115,7 @@ public class TopicQueryService {
     }
 
     public List<TopicDetailResponse> findDetailsByIds(AuthMember authMember, List<Long> ids) {
-        List<Topic> topics = topicRepository.findByIdInAndIsDeletedFalse(ids);
+        List<Topic> topics = topicRepository.findByIdIn(ids);
 
         validateTopicsCount(ids, topics);
         validateReadableTopics(authMember, topics);
@@ -163,7 +162,7 @@ public class TopicQueryService {
     public List<TopicResponse> findAllTopicsByMemberId(AuthMember authMember, Long memberId) {
 
         if (Objects.isNull(authMember.getMemberId())) {
-            return topicRepository.findAllByCreatorIdAndIsDeletedFalse(memberId)
+            return topicRepository.findAllByCreatorId(memberId)
                     .stream()
                     .filter(authMember::canRead)
                     .map(TopicResponse::fromGuestQuery)
@@ -172,7 +171,7 @@ public class TopicQueryService {
 
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAllByCreatorIdAndIsDeletedFalse(memberId)
+        return topicRepository.findAllByCreatorId(memberId)
                 .stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
@@ -193,7 +192,7 @@ public class TopicQueryService {
     private List<TopicResponse> getUserNewestTopicResponse(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAllByIsDeletedFalseOrderByLastPinUpdatedAtDesc()
+        return topicRepository.findAllByOrderByLastPinUpdatedAtDesc()
                 .stream()
                 .filter(authMember::canRead)
                 .map(topic -> TopicResponse.from(
@@ -205,7 +204,7 @@ public class TopicQueryService {
     }
 
     private List<TopicResponse> getGuestNewestTopicResponse(AuthMember authMember) {
-        return topicRepository.findAllByIsDeletedFalseOrderByLastPinUpdatedAtDesc()
+        return topicRepository.findAllByOrderByLastPinUpdatedAtDesc()
                 .stream()
                 .filter(authMember::canRead)
                 .map(TopicResponse::fromGuestQuery)
@@ -220,7 +219,7 @@ public class TopicQueryService {
     }
 
     private List<TopicResponse> getGuestBestTopicResponse(AuthMember authMember) {
-        return topicRepository.findAllByIsDeletedFalse()
+        return topicRepository.findAll()
                 .stream()
                 .filter(authMember::canRead)
                 .sorted(Comparator.comparing(Topic::countBookmarks).reversed())
@@ -231,7 +230,7 @@ public class TopicQueryService {
     private List<TopicResponse> getUserBestTopicResponse(AuthMember authMember) {
         Member member = findMemberById(authMember.getMemberId());
 
-        return topicRepository.findAllByIsDeletedFalse()
+        return topicRepository.findAll()
                 .stream()
                 .filter(authMember::canRead)
                 .sorted(Comparator.comparing(Topic::countBookmarks).reversed())

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
@@ -149,7 +149,7 @@ public class Topic extends BaseTimeEntity {
         this.topicInfo = topicInfo.removeImage();
     }
 
-    public void decrementPinCount() {
+    public void decreasePinCount() {
         pinCount--;
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
@@ -25,10 +25,12 @@ import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
 @Getter
+@Where(clause = "is_deleted = false")
 public class Topic extends BaseTimeEntity {
 
     @Id

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/Topic.java
@@ -147,6 +147,10 @@ public class Topic extends BaseTimeEntity {
         this.topicInfo = topicInfo.removeImage();
     }
 
+    public void decrementPinCount() {
+        pinCount--;
+    }
+
     public void removeBookmark(Bookmark bookmark) {
         bookmarks.remove(bookmark);
         bookmarkCount--;

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/domain/TopicRepository.java
@@ -1,5 +1,7 @@
 package com.mapbefine.mapbefine.topic.domain;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -7,32 +9,26 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
 @Repository
 public interface TopicRepository extends JpaRepository<Topic, Long> {
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    Optional<Topic> findByIdAndIsDeletedFalse(Long id);
+    Optional<Topic> findById(Long id);
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findAllByIsDeletedFalse();
+    List<Topic> findAll();
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findByIdInAndIsDeletedFalse(List<Long> ids);
+    List<Topic> findByIdIn(List<Long> ids);
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findAllByIsDeletedFalseOrderByLastPinUpdatedAtDesc();
-
-    @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findAllByCreatorIdAndIsDeletedFalse(Long creatorId);
+    List<Topic> findAllByOrderByLastPinUpdatedAtDesc();
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
     List<Topic> findAllByCreatorId(Long creatorId);
 
     @EntityGraph(attributePaths = {"creator", "permissions"})
-    List<Topic> findTopicsByBookmarksMemberIdAndIsDeletedFalse(Long memberId);
+    List<Topic> findTopicsByBookmarksMemberId(Long memberId);
 
     @Modifying(clearAutomatically = true)
     @Query("update Topic t set t.isDeleted = true where t.id = :topicId")

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
@@ -78,7 +78,9 @@ public class TopicController {
 
     @LoginRequired
     @PostMapping("/{topicId}/copy")
-    public ResponseEntity<Void> copyPin(AuthMember member, @PathVariable Long topicId, @RequestParam List<Long> pinIds) {
+    public ResponseEntity<Void> copyPin(
+            AuthMember member, @PathVariable Long topicId, @RequestParam List<Long> pinIds
+    ) {
         topicCommandService.copyPin(member, topicId, pinIds);
 
         return ResponseEntity.ok().build();
@@ -137,19 +139,20 @@ public class TopicController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/bests")
+    public ResponseEntity<List<TopicResponse>> findAllBestTopics(AuthMember authMember) {
+        List<TopicResponse> responses = topicQueryService.findAllBestTopics(authMember);
+
+        return ResponseEntity.ok(responses);
+    }
+
+    @Deprecated(since = "2023.10.06")
     @LoginRequired
     @DeleteMapping("/{topicId}")
     public ResponseEntity<Void> delete(AuthMember member, @PathVariable Long topicId) {
         topicCommandService.delete(member, topicId);
 
         return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/bests")
-    public ResponseEntity<List<TopicResponse>> findAllBestTopics(AuthMember authMember) {
-        List<TopicResponse> responses = topicQueryService.findAllBestTopics(authMember);
-
-        return ResponseEntity.ok(responses);
     }
 
 }

--- a/backend/src/main/resources/data-default.sql
+++ b/backend/src/main/resources/data-default.sql
@@ -14,3 +14,6 @@ VALUES ('dummyTopic', 'https://map-befine-official.github.io/favicon.png', 'desc
         1L,
         now(), now(), now())
 ;
+
+INSERT INTO bookmark (member_id, topic_id)
+VALUES (1L, 1L);

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
@@ -107,13 +107,12 @@ class AdminCommandServiceTest {
 
         //then
         Topic deletedTopic = topicRepository.findById(topic.getId()).get();
-        Pin deletedPin = pinRepository.findById(pin.getId()).get();
         PinImage deletedPinImage = pinImageRepository.findById(pinImage.getId()).get();
 
         assertAll(() -> {
             assertThat(member.getMemberInfo().getStatus()).isEqualTo(Status.BLOCKED);
             assertThat(deletedTopic.isDeleted()).isTrue();
-            assertThat(deletedPin.isDeleted()).isTrue();
+            assertThat(pinRepository.existsById(pin.getId())).isFalse();
             assertThat(deletedPinImage.isDeleted()).isTrue();
             assertThat(bookmarkRepository.existsByMemberIdAndTopicId(member.getId(), topic.getId())).isFalse();
             assertThat(atlasRepository.existsByMemberIdAndTopicId(member.getId(), topic.getId())).isFalse();
@@ -167,9 +166,7 @@ class AdminCommandServiceTest {
         adminCommandService.deletePin(pin.getId());
 
         //then
-        Pin deletedPin = pinRepository.findById(pin.getId()).get();
-
-        assertThat(deletedPin.isDeleted()).isTrue();
+        assertThat(pinRepository.existsById(pin.getId())).isFalse();
     }
 
     @DisplayName("Admin인 경우, 핀 이미지를 삭제할 수 있다.")

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
@@ -112,16 +112,15 @@ class AdminCommandServiceTest {
         adminCommandService.blockMember(member.getId());
 
         //then
-        PinImage deletedPinImage = pinImageRepository.findById(pinImage.getId()).get();
         Member blockedMember = memberRepository.findById(member.getId()).get();
 
         assertAll(
                 () -> assertThat(blockedMember.getMemberInfo().getStatus()).isEqualTo(Status.BLOCKED),
                 () -> assertThat(topicRepository.existsById(topic.getId())).isFalse(),
                 () -> assertThat(pinRepository.existsById(pin.getId())).isFalse(),
-                () -> assertThat(deletedPinImage.isDeleted()).isTrue(),
-                () -> assertThat(
-                        bookmarkRepository.existsByMemberIdAndTopicId(member.getId(), topic.getId())).isFalse(),
+                () -> assertThat(pinImageRepository.existsById(pinImage.getId())).isFalse(),
+                () -> assertThat(bookmarkRepository.existsByMemberIdAndTopicId(member.getId(), topic.getId()))
+                        .isFalse(),
                 () -> assertThat(atlasRepository.existsByMemberIdAndTopicId(member.getId(), topic.getId())).isFalse(),
                 () -> assertThat(permissionRepository.existsByTopicIdAndMemberId(topic.getId(), member.getId()))
                         .isFalse()
@@ -186,9 +185,7 @@ class AdminCommandServiceTest {
         adminCommandService.deletePinImage(pinImage.getId());
 
         //then
-        PinImage deletedPinImage = pinImageRepository.findById(pinImage.getId()).get();
-
-        assertThat(deletedPinImage.isDeleted()).isTrue();
+        assertThat(pinImageRepository.findById(pinImage.getId())).isEmpty();
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminQueryServiceTest.java
@@ -1,11 +1,9 @@
 package com.mapbefine.mapbefine.admin.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.mapbefine.mapbefine.admin.dto.AdminMemberDetailResponse;
 import com.mapbefine.mapbefine.admin.dto.AdminMemberResponse;
-import com.mapbefine.mapbefine.auth.domain.AuthMember;
 import com.mapbefine.mapbefine.common.annotation.ServiceTest;
 import com.mapbefine.mapbefine.location.LocationFixture;
 import com.mapbefine.mapbefine.location.domain.Location;
@@ -14,7 +12,6 @@ import com.mapbefine.mapbefine.member.MemberFixture;
 import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.member.domain.Role;
-import com.mapbefine.mapbefine.permission.exception.PermissionException.PermissionForbiddenException;
 import com.mapbefine.mapbefine.pin.PinFixture;
 import com.mapbefine.mapbefine.pin.domain.Pin;
 import com.mapbefine.mapbefine.pin.domain.PinRepository;
@@ -72,6 +69,7 @@ class AdminQueryServiceTest {
                 .ignoringFields("updatedAt")
                 .isEqualTo(AdminMemberDetailResponse.of(member, List.of(topic), List.of(pin)));
     }
+    
     @Test
     @DisplayName("모든 사용자와 관련된 세부 정보를 모두 조회할 수 있다.")
     void findAllMemberDetails_Success() {

--- a/backend/src/test/java/com/mapbefine/mapbefine/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/auth/application/AuthServiceTest.java
@@ -1,0 +1,94 @@
+package com.mapbefine.mapbefine.auth.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.mapbefine.mapbefine.admin.application.AdminCommandService;
+import com.mapbefine.mapbefine.auth.domain.AuthMember;
+import com.mapbefine.mapbefine.common.annotation.ServiceTest;
+import com.mapbefine.mapbefine.common.exception.UnauthorizedException;
+import com.mapbefine.mapbefine.member.MemberFixture;
+import com.mapbefine.mapbefine.member.domain.Member;
+import com.mapbefine.mapbefine.member.domain.MemberRepository;
+import com.mapbefine.mapbefine.member.domain.Role;
+import com.mapbefine.mapbefine.permission.domain.Permission;
+import com.mapbefine.mapbefine.permission.domain.PermissionRepository;
+import com.mapbefine.mapbefine.topic.TopicFixture;
+import com.mapbefine.mapbefine.topic.domain.Topic;
+import com.mapbefine.mapbefine.topic.domain.TopicRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@ServiceTest
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+    @Autowired
+    private AdminCommandService adminCommandService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TopicRepository topicRepository;
+    @Autowired
+    private PermissionRepository permissionRepository;
+    private Member member;
+    private Topic topicWithPermission;
+    private Topic createdTopic;
+
+
+    @BeforeEach
+    void setUp() {
+        Member admin = memberRepository.save(MemberFixture.create("admin", "admin@member.com", Role.ADMIN));
+        member = memberRepository.save(MemberFixture.create("member", "member1@member.com", Role.USER));
+        topicWithPermission = topicRepository.save(TopicFixture.createPrivateAndGroupOnlyTopic(admin));
+        createdTopic = topicRepository.save(TopicFixture.createPublicAndAllMembersTopic(admin));
+        permissionRepository.save(Permission.createPermissionAssociatedWithTopicAndMember(topicWithPermission, member));
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Test
+    @DisplayName("인증된 회원 정보를 가져올 때, 차단 혹은 탈퇴한 회원의 정보는 가져오지 않는다.")
+    void findAuthMemberByMemberId_Success_notContainingNotNormalMember() {
+        // given
+        adminCommandService.blockMember(member.getId());
+
+        // when
+        // then
+        assertThatThrownBy(() -> authService.findAuthMemberByMemberId(member.getId()))
+                .isInstanceOf(UnauthorizedException.class);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Test
+    @DisplayName("인증된 회원 정보를 가져올 때, 삭제된 지도에 대해서는 권한을 부여하지 않는다. (soft delete 반영)")
+    void findAuthMemberByMemberId_Success_notContainingSoftDeletedPermission() {
+        // given
+        adminCommandService.deleteTopic(topicWithPermission.getId());
+
+        // when
+        AuthMember authMember = authService.findAuthMemberByMemberId(member.getId());
+
+        // then
+        assertThat(authMember.canPinCreateOrUpdate(topicWithPermission)).isFalse();
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Test
+    @DisplayName("인증된 회원 정보를 가져올 때, 삭제된 지도에 대해서는 생성자 여부를 확인하지 않는다. (soft delete 반영)")
+    void findAuthMemberByMemberId_Success_notContainingSoftDeletedCreatedTopic() {
+        // given
+        adminCommandService.deleteTopic(createdTopic.getId());
+
+        // when
+        AuthMember authMember = authService.findAuthMemberByMemberId(member.getId());
+
+        // then
+        assertThat(authMember.canTopicUpdate(createdTopic)).isFalse();
+    }
+
+}

--- a/backend/src/test/java/com/mapbefine/mapbefine/common/annotation/ServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/common/annotation/ServiceTest.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Service;
                 ),
                 @Filter(
                         type = FilterType.REGEX,
-                        pattern = "com.mapbefine.mapbefine.auth.application.*"
+                        pattern = "com.mapbefine.mapbefine.auth.application.TokenService"
                 )
         }
 )

--- a/backend/src/test/java/com/mapbefine/mapbefine/location/application/LocationQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/location/application/LocationQueryServiceTest.java
@@ -123,7 +123,7 @@ class LocationQueryServiceTest {
         /// TODO: 2023/10/05 Topic의 pinCount를 줄이는 로직을 삭제 로직과 통합하지 못해 테스트에서 세부 구현이 드러나는 문제가 있음
         for (int i = 0; i < deleteCounts; i++) {
             Pin delete = topic.getPins().get(i);
-            delete.decrementTopicPinCount();
+            delete.decreaseTopicPinCount();
             pinRepository.deleteById(delete.getId());
         }
     }

--- a/backend/src/test/java/com/mapbefine/mapbefine/location/application/LocationQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/location/application/LocationQueryServiceTest.java
@@ -16,6 +16,8 @@ import com.mapbefine.mapbefine.member.domain.Member;
 import com.mapbefine.mapbefine.member.domain.MemberRepository;
 import com.mapbefine.mapbefine.member.domain.Role;
 import com.mapbefine.mapbefine.pin.PinFixture;
+import com.mapbefine.mapbefine.pin.domain.Pin;
+import com.mapbefine.mapbefine.pin.domain.PinRepository;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
@@ -38,6 +40,8 @@ class LocationQueryServiceTest {
     private MemberRepository memberRepository;
     @Autowired
     private TopicRepository topicRepository;
+    @Autowired
+    private PinRepository pinRepository;
 
     @Autowired
     private LocationQueryService locationQueryService;
@@ -56,9 +60,9 @@ class LocationQueryServiceTest {
         locationRepository.save(allPinsLocation);
 
         topics = List.of(
-                createAndSaveTopic("준팍의 또간집", 1),
-                createAndSaveTopic("도이의 또간집", 2),
-                createAndSaveTopic("패트릭의 또간집", 3)
+                createAndSaveTopic("준팍의 또간집", 2),
+                createAndSaveTopic("도이의 또간집", 3),
+                createAndSaveTopic("패트릭의 또간집", 4)
         );
 
     }
@@ -68,12 +72,13 @@ class LocationQueryServiceTest {
         for (int i = 0; i < pinCounts; i++) {
             PinFixture.create(allPinsLocation, topic, member);
         }
+
         return topicRepository.save(topic);
     }
 
     @Test
     @DisplayName("주어진 좌표의 3KM 이내 Topic들을 Pin 개수의 내림차순으로 정렬하여 조회한다.")
-    void findNearbyTopicsSortedByPinCount() {
+    void findNearbyTopicsSortedByPinCount_Success() {
         // given
         Coordinate baseCoordinate = BASE_COORDINATE;
 
@@ -91,6 +96,36 @@ class LocationQueryServiceTest {
                 .collect(Collectors.toList());
 
         assertThat(currentTopics).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("반경 내 핀을 찾을 때, soft delete 된 핀은 제외한다.")
+    void findNearbyTopicsSortedByPinCount_Success_notContainingSoftDeletedPins() {
+        // given
+        Coordinate baseCoordinate = BASE_COORDINATE;
+        Topic second = topics.get(1);
+        deletePins(second, 2);
+
+        // when
+        List<TopicResponse> currentTopics = locationQueryService.findNearbyTopicsSortedByPinCount(
+                authMember,
+                baseCoordinate.getLatitude(),
+                baseCoordinate.getLongitude()
+        );
+
+        // then
+        assertThat(currentTopics)
+                .extracting("id")
+                .containsExactly(topics.get(2).getId(), topics.get(0).getId(), topics.get(1).getId());
+    }
+
+    private void deletePins(Topic topic, int deleteCounts) {
+        /// TODO: 2023/10/05 Topic의 pinCount를 줄이는 로직을 삭제 로직과 통합하지 못해 테스트에서 세부 구현이 드러나는 문제가 있음
+        for (int i = 0; i < deleteCounts; i++) {
+            Pin delete = topic.getPins().get(i);
+            delete.decrementTopicPinCount();
+            pinRepository.deleteById(delete.getId());
+        }
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/member/application/MemberQueryServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/member/application/MemberQueryServiceTest.java
@@ -178,6 +178,26 @@ class MemberQueryServiceTest {
     }
 
     @Test
+    @DisplayName("로그인한 회원의 모든 지도를 가져올 때, 삭제된 지도는 제외한다. (soft delete 반영)")
+    void findMyAllTopics_Success_notContainingSoftDeleted() {
+        // given
+        List<Long> topicIds = topics.stream()
+                .map(Topic::getId)
+                .toList();
+
+        // when
+        Long deleted = topicIds.get(0);
+        topicRepository.deleteById(deleted);
+        topicRepository.flush();
+        List<TopicResponse> myAllTopics = memberQueryService.findMyAllTopics(authMember);
+
+        // then
+        assertThat(myAllTopics).hasSize(topics.size() - 1);
+        assertThat(myAllTopics).extractingResultOf("id")
+                .doesNotContain(deleted);
+    }
+
+    @Test
     @DisplayName("로그인한 회원이 생성한 모든 핀을 가져올 수 있다.")
     void findMyAllPins_Success() {
         // given

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
@@ -29,14 +29,13 @@ import com.mapbefine.mapbefine.pin.exception.PinException.PinForbiddenException;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
+import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @ServiceTest
 class PinCommandServiceTest {
@@ -200,7 +199,7 @@ class PinCommandServiceTest {
         pinCommandService.removeById(authMember, pinId);
 
         // then
-        assertThat(pinRepository.findByIdAndIsDeletedFalse(pinId))
+        assertThat(pinRepository.findById(pinId))
                 .isEmpty();
         assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pinId))
                 .isEmpty();

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/application/PinCommandServiceTest.java
@@ -201,7 +201,7 @@ class PinCommandServiceTest {
         // then
         assertThat(pinRepository.findById(pinId))
                 .isEmpty();
-        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pinId))
+        assertThat(pinImageRepository.findById(pinId))
                 .isEmpty();
     }
 
@@ -267,7 +267,7 @@ class PinCommandServiceTest {
         pinCommandService.removeImageById(authMember, pinImageId);
 
         // then
-        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pinImageId))
+        assertThat(pinImageRepository.findById(pinImageId))
                 .isEmpty();
     }
 

--- a/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinImageRepositoryTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/pin/domain/PinImageRepositoryTest.java
@@ -14,13 +14,12 @@ import com.mapbefine.mapbefine.pin.PinImageFixture;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-import java.util.List;
 
 @DataJpaTest
 class PinImageRepositoryTest {
@@ -62,7 +61,7 @@ class PinImageRepositoryTest {
         pinImageRepository.deleteById(pinImageId);
 
         //then
-        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pinImageId))
+        assertThat(pinImageRepository.findById(pinImageId))
                 .isEmpty();
     }
 
@@ -81,7 +80,7 @@ class PinImageRepositoryTest {
         pinImageRepository.deleteAllByPinId(pin.getId());
 
         //then
-        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pin.getId()))
+        assertThat(pinImageRepository.findById(pin.getId()))
                 .isEmpty();
     }
 
@@ -102,9 +101,9 @@ class PinImageRepositoryTest {
         pinImageRepository.deleteAllByPinIds(List.of(pin.getId(), otherPin.getId()));
 
         //then
-        assertThat(pinImageRepository.findByIdAndIsDeletedFalse(pin.getId()))
+        assertThat(pinImageRepository.findById(pin.getId()))
                 .isEmpty();
-        assertThat(pinImageRepository.findAllByPinIdAndIsDeletedFalse(otherPin.getId()))
+        assertThat(pinImageRepository.findAllByPinId(otherPin.getId()))
                 .isEmpty();
     }
 

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/application/TopicCommandServiceTest.java
@@ -29,13 +29,12 @@ import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicBadRequestException;
 import com.mapbefine.mapbefine.topic.exception.TopicException.TopicForbiddenException;
+import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.Collections;
-import java.util.List;
 
 @ServiceTest
 class TopicCommandServiceTest {
@@ -398,9 +397,7 @@ class TopicCommandServiceTest {
         topicCommandService.delete(adminAuthMember, topic.getId());
 
         //then
-        Topic deletedTopic = topicRepository.findById(topic.getId()).get();
-
-        assertThat(deletedTopic.isDeleted()).isTrue();
+        assertThat(topicRepository.existsById(topic.getId())).isFalse();
     }
 
     @Test

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicRepositoryTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/domain/TopicRepositoryTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
-import java.util.List;
-
 @DataJpaTest
 class TopicRepositoryTest {
 
@@ -43,8 +41,7 @@ class TopicRepositoryTest {
         topicRepository.deleteById(topic.getId());
 
         //then
-        Topic deletedTopic = topicRepository.findById(topic.getId()).get();
-        assertThat(deletedTopic.isDeleted()).isTrue();
+        assertThat(topicRepository.existsById(topic.getId())).isFalse();
     }
 
     @Test
@@ -62,9 +59,7 @@ class TopicRepositoryTest {
         topicRepository.deleteAllByMemberId(member.getId());
 
         //then
-        List<Topic> deletedTopics = topicRepository.findAllByCreatorId(member.getId());
-        assertThat(deletedTopics).hasSize(10)
-                .extractingResultOf("isDeleted")
-                .containsOnly(true);
+        assertThat(topicRepository.findAllByCreatorId(member.getId()))
+                .isEmpty();
     }
 }


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
Repository 메서드에 `IsDeletedFalse`를 붙여 조회 기능에 soft delete을 반영함에 따라  
지연 로딩으로 정보를 조회하는 경우, 삭제된 토픽/핀도 조회하게 되는 문제가 있었습니다.

이를 해결하기 위한 방법 중 엔티티에 `@Where`을 적용하는 것을 선택했습니다.  
stream, filter는 지연로딩인 모든 연관 관계의 getter에 대해 이를 적용해주어야 한다는 문제가 있기 때문입니다.  
빠른 적용이 필요한 상황에서도 오히려 시간이 더 오래 걸릴 수 있습니다.  
또, 그에 비해 `@Where` 적용 시, 수정이 필요한 대부분은 관리자 기능 및 테스트 코드인 데에 비해  
새로 엔티티가 추가될 때마다/연관관계가 변경될때마다 getter를 수정하는 작업을 하기에는 유지보수성도 떨어진다고 판단했습니다. 


### 고려해야 할 연관관계 (테스트 작성)
- [x] topic.getPins
- [x] member.getCreatedPins
- [x] location.getPins
- [x] member.getCreatedTopics
- [x] pin.getPinImages
- pin.getTopic (즉시로딩, topic이 삭제되었다면 pin도 삭제된 상황이므로 해당 X)
- atlas.getTopic (즉시로딩, soft delete 해당 X)
- bookmark.getTopic (즉시로딩, soft delete 해당 X)



### 작업 내용

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] 지연로딩 대상인 엔티티에 Where 적용, 테스트 작성
    - [x] Where 적용으로 인해 깨지는 테스트 수정
- [x] 기존에 JPQL에 조건부를 붙인 조회 쿼리를 Where 적용으로 변경
    - [x] Where 적용으로 인해 깨지는 테스트 수정
### 추가 작업
**Pin을 삭제할 경우 Topic의 pinCount 컬럼을 업데이트하는 로직이 없는 것을 발견하여 이를 추가했습니다.** ([해당 커밋](https://github.com/woowacourse-teams/2023-map-befine/commit/9db5da3309728bc7dd9fe8d1b81951f21bb103fe))  
  - 그동안은 Pin을 삭제할 일이 없었기 때문에 놓쳤던 부분인 것 같아요.
  - 그런데 우리는 Pin을 삭제할때 Repository를 거쳐 쿼리를 실행하므로, Pin 삭제 로직과 Topic의 pinCount를 완전히 통합하기가 어려웠습니다.
  - 이 부분에 대해서는 TODO 주석을 다수 남겨두었는데, 같이 얘기해보면 좋을 것 같아요.
  

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
일종의 버그 해결이기 때문에 Hotfix라고 생각하지만, 개발 서버에도 먼저 반영될 사안이라고 생각해 develop-BE로 PR 보냅니다.  
개발서버 배포 후 바로 운영서버 배포하면 될 것 같습니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
closed #540

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
