### PR TITLE
[BE] Refactor/#563 RestDocs 응답 오류(500) 해결 및 상태코드 검증 추가

### DIFF
--- a/backend/src/docs/asciidoc/admin.adoc
+++ b/backend/src/docs/asciidoc/admin.adoc
@@ -1,29 +1,29 @@
-// == 관리자 기능
-//
-// === 전체 회원 조회
-//
-// operation::admin-controller-test/find-all-member-details[snippets='http-request,http-response']
-//
-// === 회원 상세 조회
-//
-// operation::admin-controller-test/find-member[snippets='http-request,http-response']
-//
-// === 회원 차단(삭제)
-//
-// operation::admin-controller-test/delete-member[snippets='http-request,http-response']
-//
-// === 토픽 삭제
-//
-// operation::admin-controller-test/delete-topic[snippets='http-request,http-response']
-//
-// === 토픽 이미지 삭제
-//
-// operation::admin-controller-test/delete-topic-image[snippets='http-request,http-response']
-//
-// === 핀 삭제
-//
-// operation::admin-controller-test/delete-pin[snippets='http-request,http-response']
-//
-// === 핀 이미지 삭제
-//
-// operation::admin-controller-test/delete-pin-image[snippets='http-request,http-response']
+== 관리자 기능
+
+=== 전체 회원 조회
+
+operation::admin-controller-test/find-all-member-details[snippets='http-request,http-response']
+
+=== 회원 상세 조회
+
+operation::admin-controller-test/find-member[snippets='http-request,http-response']
+
+=== 회원 차단(삭제)
+
+operation::admin-controller-test/delete-member[snippets='http-request,http-response']
+
+=== 토픽 삭제
+
+operation::admin-controller-test/delete-topic[snippets='http-request,http-response']
+
+=== 토픽 이미지 삭제
+
+operation::admin-controller-test/delete-topic-image[snippets='http-request,http-response']
+
+=== 핀 삭제
+
+operation::admin-controller-test/delete-pin[snippets='http-request,http-response']
+
+=== 핀 이미지 삭제
+
+operation::admin-controller-test/delete-pin-image[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/pin.adoc
+++ b/backend/src/docs/asciidoc/pin.adoc
@@ -20,10 +20,6 @@ operation::pin-controller-test/add[snippets='http-request,http-response']
 
 operation::pin-controller-test/update[snippets='http-request,http-response']
 
-=== 핀 삭제
-
-operation::pin-controller-test/delete[snippets='http-request,http-response']
-
 === 핀 이미지 추가
 
 operation::pin-controller-test/add-image[snippets='http-request,http-response']

--- a/backend/src/docs/asciidoc/topic.adoc
+++ b/backend/src/docs/asciidoc/topic.adoc
@@ -40,7 +40,3 @@ operation::topic-controller-test/copy-pin[snippets='http-request,http-response']
 
 operation::topic-controller-test/update[snippets='http-request,http-response']
 
-=== 토픽 삭제
-
-operation::topic-controller-test/delete[snippets='http-request,http-response']
-

--- a/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/member/application/MemberQueryService.java
@@ -74,13 +74,6 @@ public class MemberQueryService {
                 .toList();
     }
 
-    private List<Topic> findTopicsInAtlas(Member member) {
-        return member.getAtlantes()
-                .stream()
-                .map(Atlas::getTopic)
-                .toList();
-    }
-
     private boolean isInAtlas(Long memberId, Long topicId) {
         return atlasRepository.existsByMemberIdAndTopicId(memberId, topicId);
     }
@@ -95,6 +88,13 @@ public class MemberQueryService {
                         true,
                         isInBookmark(authMember.getMemberId(), topic.getId())
                 ))
+                .toList();
+    }
+
+    private List<Topic> findTopicsInAtlas(Member member) {
+        return member.getAtlantes()
+                .stream()
+                .map(Atlas::getTopic)
                 .toList();
     }
 

--- a/backend/src/main/java/com/mapbefine/mapbefine/pin/presentation/PinController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/pin/presentation/PinController.java
@@ -65,6 +65,7 @@ public class PinController {
                 .build();
     }
 
+    @Deprecated(since = "2023.10.10 (이미지 삭제 로직 불완전, 사용되지 않는 API)")
     @LoginRequired
     @DeleteMapping("/{pinId}")
     public ResponseEntity<Void> delete(AuthMember member, @PathVariable Long pinId) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
@@ -146,7 +146,7 @@ public class TopicController {
         return ResponseEntity.ok(responses);
     }
 
-    @Deprecated(since = "2023.10.06")
+    @Deprecated(since = "2023.10.06 (연관관계 삭제 불완전, 사용되지 않는 API)")
     @LoginRequired
     @DeleteMapping("/{topicId}")
     public ResponseEntity<Void> delete(AuthMember member, @PathVariable Long topicId) {

--- a/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/topic/presentation/TopicController.java
@@ -77,6 +77,18 @@ public class TopicController {
     }
 
     @LoginRequired
+    @PutMapping("/{topicId}")
+    public ResponseEntity<Void> update(
+            AuthMember member,
+            @PathVariable Long topicId,
+            @RequestBody TopicUpdateRequest request
+    ) {
+        topicCommandService.updateTopicInfo(member, topicId, request);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @LoginRequired
     @PostMapping("/{topicId}/copy")
     public ResponseEntity<Void> copyPin(
             AuthMember member, @PathVariable Long topicId, @RequestParam List<Long> pinIds
@@ -125,18 +137,6 @@ public class TopicController {
         List<TopicResponse> responses = topicQueryService.findAllByOrderByUpdatedAtDesc(member);
 
         return ResponseEntity.ok(responses);
-    }
-
-    @LoginRequired
-    @PutMapping("/{topicId}")
-    public ResponseEntity<Void> update(
-            AuthMember member,
-            @PathVariable Long topicId,
-            @RequestBody TopicUpdateRequest request
-    ) {
-        topicCommandService.updateTopicInfo(member, topicId, request);
-
-        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/bests")

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/presentation/AdminControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/presentation/AdminControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 class AdminControllerTest extends RestDocsIntegration {
 
@@ -74,7 +75,7 @@ class AdminControllerTest extends RestDocsIntegration {
     private AdminAuthInterceptor adminAuthInterceptor;
 
     @BeforeEach
-    void setAll() throws Exception {
+    void setAll() {
         given(adminAuthInterceptor.preHandle(any(), any(), any())).willReturn(true);
     }
 
@@ -88,10 +89,10 @@ class AdminControllerTest extends RestDocsIntegration {
 
         given(adminQueryService.findAllMemberDetails()).willReturn(response);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/admin/members")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/admin/members")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @DisplayName("멤버 상세 조회")
@@ -109,10 +110,10 @@ class AdminControllerTest extends RestDocsIntegration {
 
         given(adminQueryService.findMemberDetail(any())).willReturn(response);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/admin/members/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/admin/members/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @DisplayName("멤버 차단(블랙리스트)")
@@ -120,10 +121,10 @@ class AdminControllerTest extends RestDocsIntegration {
     void deleteMember() throws Exception {
         doNothing().when(adminCommandService).blockMember(any());
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/admin/members/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/admin/members/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
     @DisplayName("토픽 삭제")
@@ -131,10 +132,10 @@ class AdminControllerTest extends RestDocsIntegration {
     void deleteTopic() throws Exception {
         doNothing().when(adminCommandService).deleteTopic(any());
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/admin/topics/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/admin/topics/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
     @DisplayName("토픽 이미지 삭제")
@@ -142,10 +143,10 @@ class AdminControllerTest extends RestDocsIntegration {
     void deleteTopicImage() throws Exception {
         doNothing().when(adminCommandService).deleteTopicImage(any());
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/admin/topics/1/images")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/admin/topics/1/images")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
     @DisplayName("핀 삭제")
@@ -153,10 +154,10 @@ class AdminControllerTest extends RestDocsIntegration {
     void deletePin() throws Exception {
         doNothing().when(adminCommandService).deletePin(any());
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/admin/pins/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/admin/pins/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
     @DisplayName("토픽 이미지 삭제")
@@ -164,9 +165,9 @@ class AdminControllerTest extends RestDocsIntegration {
     void deletePinImage() throws Exception {
         doNothing().when(adminCommandService).deletePinImage(any());
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/admin/pins/images/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/admin/pins/images/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/presentation/AdminControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/presentation/AdminControllerTest.java
@@ -90,7 +90,7 @@ class AdminControllerTest extends RestDocsIntegration {
         given(adminQueryService.findAllMemberDetails()).willReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/admin/members")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                        .header(AUTHORIZATION, "testKey"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andDo(restDocs.document());
     }
@@ -111,7 +111,7 @@ class AdminControllerTest extends RestDocsIntegration {
         given(adminQueryService.findMemberDetail(any())).willReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.get("/admin/members/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                        .header(AUTHORIZATION, "testKey"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andDo(restDocs.document());
     }
@@ -122,7 +122,7 @@ class AdminControllerTest extends RestDocsIntegration {
         doNothing().when(adminCommandService).blockMember(any());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/admin/members/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                        .header(AUTHORIZATION, "testKey"))
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
                 .andDo(restDocs.document());
     }
@@ -133,7 +133,7 @@ class AdminControllerTest extends RestDocsIntegration {
         doNothing().when(adminCommandService).deleteTopic(any());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/admin/topics/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                        .header(AUTHORIZATION, "testKey"))
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
                 .andDo(restDocs.document());
     }
@@ -144,7 +144,7 @@ class AdminControllerTest extends RestDocsIntegration {
         doNothing().when(adminCommandService).deleteTopicImage(any());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/admin/topics/1/images")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                        .header(AUTHORIZATION, "testKey"))
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
                 .andDo(restDocs.document());
     }
@@ -155,7 +155,7 @@ class AdminControllerTest extends RestDocsIntegration {
         doNothing().when(adminCommandService).deletePin(any());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/admin/pins/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                        .header(AUTHORIZATION, "testKey"))
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
                 .andDo(restDocs.document());
     }
@@ -166,7 +166,7 @@ class AdminControllerTest extends RestDocsIntegration {
         doNothing().when(adminCommandService).deletePinImage(any());
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/admin/pins/images/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                        .header(AUTHORIZATION, "testKey"))
                 .andExpect(MockMvcResultMatchers.status().isNoContent())
                 .andDo(restDocs.document());
     }

--- a/backend/src/test/java/com/mapbefine/mapbefine/atlas/presentation/AtlasControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/atlas/presentation/AtlasControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 class AtlasControllerTest extends RestDocsIntegration {
 
@@ -23,10 +24,10 @@ class AtlasControllerTest extends RestDocsIntegration {
         doNothing().when(atlasCommandService).addTopic(any(), any());
 
         // then
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/atlas/topics?id=1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.post("/atlas/topics?id=1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -35,10 +36,10 @@ class AtlasControllerTest extends RestDocsIntegration {
         doNothing().when(atlasCommandService).removeTopic(any(), any());
 
         // then
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/atlas/topics?id=1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/atlas/topics?id=1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/bookmark/presentation/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/bookmark/presentation/BookmarkControllerTest.java
@@ -11,23 +11,23 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 class BookmarkControllerTest extends RestDocsIntegration {
 
     @MockBean
     private BookmarkCommandService bookmarkCommandService;
 
-
     @Test
     @DisplayName("토픽을 회원의 즐겨찾기에 추가")
     void addTopicInBookmark() throws Exception {
         given(bookmarkCommandService.addTopicInBookmark(any(), any())).willReturn(1L);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/bookmarks/topics")
+        mockMvc.perform(MockMvcRequestBuilders.post("/bookmarks/topics")
                         .queryParam("id", String.valueOf(1))
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -35,11 +35,11 @@ class BookmarkControllerTest extends RestDocsIntegration {
     void deleteTopicInBookmark() throws Exception {
         doNothing().when(bookmarkCommandService).deleteTopicInBookmark(any(), any());
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/bookmarks/topics")
+        mockMvc.perform(MockMvcRequestBuilders.delete("/bookmarks/topics")
                         .queryParam("id", String.valueOf(1L))
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/location/presentation/LocationControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/location/presentation/LocationControllerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 class LocationControllerTest extends RestDocsIntegration {
 
@@ -63,13 +64,13 @@ class LocationControllerTest extends RestDocsIntegration {
                 .willReturn(responses);
 
         //then
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/locations/bests")
+        mockMvc.perform(MockMvcRequestBuilders.get("/locations/bests")
                         .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
                         .contentType(MediaType.APPLICATION_JSON)
                         .param("latitude", String.valueOf(latitude))
-                        .param("longitude", String.valueOf(longitude))
-        ).andDo(restDocs.document());
+                        .param("longitude", String.valueOf(longitude)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/member/presentation/MemberControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/member/presentation/MemberControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.mapbefine.mapbefine.common.RestDocsIntegration;
 import com.mapbefine.mapbefine.location.LocationFixture;
+import com.mapbefine.mapbefine.member.application.MemberCommandService;
 import com.mapbefine.mapbefine.member.application.MemberQueryService;
 import com.mapbefine.mapbefine.member.dto.request.MemberUpdateRequest;
 import com.mapbefine.mapbefine.member.dto.response.MemberDetailResponse;
@@ -19,11 +20,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 class MemberControllerTest extends RestDocsIntegration {
 
     @MockBean
     private MemberQueryService memberQueryService;
+    @MockBean
+    private MemberCommandService memberCommandService;
 
     @Test
     @DisplayName("회원 목록 조회")
@@ -41,10 +45,10 @@ class MemberControllerTest extends RestDocsIntegration {
 
         given(memberQueryService.findAll()).willReturn(memberResponses);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/members")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/members")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -60,10 +64,10 @@ class MemberControllerTest extends RestDocsIntegration {
 
         given(memberQueryService.findMemberDetail(any())).willReturn(memberDetailResponse);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/members/my/profiles")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/members/my/profiles")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -95,10 +99,10 @@ class MemberControllerTest extends RestDocsIntegration {
 
         given(memberQueryService.findAllTopicsInAtlas(any())).willReturn(responses);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/members/my/atlas")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/members/my/atlas")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -130,10 +134,10 @@ class MemberControllerTest extends RestDocsIntegration {
 
         given(memberQueryService.findAllTopicsInBookmark(any())).willReturn(responses);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/members/my/bookmarks")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/members/my/bookmarks")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -165,10 +169,10 @@ class MemberControllerTest extends RestDocsIntegration {
 
         given(memberQueryService.findMyAllTopics(any())).willReturn(responses);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/members/my/topics")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/members/my/topics")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -196,10 +200,10 @@ class MemberControllerTest extends RestDocsIntegration {
 
         given(memberQueryService.findMyAllPins(any())).willReturn(responses);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/members/my/pins")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/members/my/pins")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -207,12 +211,12 @@ class MemberControllerTest extends RestDocsIntegration {
     void updateMyInfo() throws Exception {
         MemberUpdateRequest request = new MemberUpdateRequest("새로운 닉네임");
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.patch("/members/my/profiles")
+        mockMvc.perform(MockMvcRequestBuilders.patch("/members/my/profiles")
                         .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-        ).andDo(restDocs.document());
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/permission/presentation/PermissionControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/permission/presentation/PermissionControllerTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 class PermissionControllerTest extends RestDocsIntegration {
 
@@ -31,21 +32,21 @@ class PermissionControllerTest extends RestDocsIntegration {
     void addPermission() throws Exception {
         PermissionRequest request = new PermissionRequest(1L, List.of(1L, 2L, 3L));
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/permissions")
+        mockMvc.perform(MockMvcRequestBuilders.post("/permissions")
                         .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request))
-        ).andDo(restDocs.document());
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andDo(restDocs.document());
     }
 
     @Test
     @DisplayName("권한 삭제")
     void deletePermission() throws Exception {
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/permissions/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/permissions/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -59,10 +60,10 @@ class PermissionControllerTest extends RestDocsIntegration {
 
         given(permissionQueryService.findTopicAccessDetailById(any())).willReturn(response);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/permissions/topics/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/permissions/topics/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -82,10 +83,10 @@ class PermissionControllerTest extends RestDocsIntegration {
 
         given(permissionQueryService.findPermissionById(any())).willReturn(permissionMemberDetailResponse);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/permissions/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/permissions/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
 }

--- a/backend/src/test/java/com/mapbefine/mapbefine/permission/presentation/PermissionControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/permission/presentation/PermissionControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 import com.mapbefine.mapbefine.common.RestDocsIntegration;
 import com.mapbefine.mapbefine.member.dto.response.MemberDetailResponse;
 import com.mapbefine.mapbefine.member.dto.response.MemberResponse;
+import com.mapbefine.mapbefine.permission.application.PermissionCommandService;
 import com.mapbefine.mapbefine.permission.application.PermissionQueryService;
 import com.mapbefine.mapbefine.permission.dto.request.PermissionRequest;
 import com.mapbefine.mapbefine.permission.dto.response.PermissionMemberDetailResponse;
@@ -26,6 +27,9 @@ class PermissionControllerTest extends RestDocsIntegration {
 
     @MockBean
     private PermissionQueryService permissionQueryService;
+    @MockBean
+    private PermissionCommandService permissionCommandService;
+
 
     @Test
     @DisplayName("권한 추가")

--- a/backend/src/test/java/com/mapbefine/mapbefine/topic/presentation/TopicControllerTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/topic/presentation/TopicControllerTest.java
@@ -3,6 +3,9 @@ package com.mapbefine.mapbefine.topic.presentation;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpMethod.POST;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
 
 import com.mapbefine.mapbefine.common.RestDocsIntegration;
 import com.mapbefine.mapbefine.pin.dto.response.PinResponse;
@@ -15,19 +18,17 @@ import com.mapbefine.mapbefine.topic.dto.request.TopicMergeRequestWithoutImage;
 import com.mapbefine.mapbefine.topic.dto.request.TopicUpdateRequest;
 import com.mapbefine.mapbefine.topic.dto.response.TopicDetailResponse;
 import com.mapbefine.mapbefine.topic.dto.response.TopicResponse;
-import java.io.File;
 import java.time.LocalDateTime;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Image 칼람 추가됨으로 인해 수정 필요
+class TopicControllerTest extends RestDocsIntegration {
 
     private static final List<TopicResponse> RESPONSES = List.of(new TopicResponse(
             1L,
@@ -51,30 +52,15 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
             LocalDateTime.now()
     ));
 
-    private File mockFile;
-
     @MockBean
     private TopicCommandService topicCommandService;
     @MockBean
     private TopicQueryService topicQueryService;
 
-    @BeforeEach
-    void setUp() {
-        mockFile = new File(
-                getClass().getClassLoader()
-                        .getResource("test.png")
-                        .getPath()
-        );
-    }
-
-
     @Test
     @DisplayName("토픽 새로 생성")
     void create() throws Exception {
         given(topicCommandService.saveTopic(any(), any())).willReturn(1L);
-        File mockFile = new File(getClass().getClassLoader().getResource("test.png").getPath());
-        MultiValueMap<String, Object> param = new LinkedMultiValueMap<>();
-
         TopicCreateRequestWithoutImage request = new TopicCreateRequestWithoutImage(
                 "준팍의 안갈집",
                 "준팍이 두번 다시 안갈집",
@@ -82,25 +68,23 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
                 PermissionType.ALL_MEMBERS,
                 List.of(1L, 2L, 3L)
         );
+        MockMultipartFile requestJson = new MockMultipartFile("request", "request", APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request));
+        MockMultipartFile image = new MockMultipartFile("image", "test.png", IMAGE_PNG_VALUE, "data".getBytes());
 
-        param.add("image", mockFile);
-        param.add("request", request);
-
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/topics/new")
+        mockMvc.perform(MockMvcRequestBuilders.multipart(POST, "/topics/new")
+                        .file(image)
+                        .file(requestJson)
                         .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .content(objectMapper.writeValueAsString(param))
-        ).andDo(restDocs.document());
+                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andDo(restDocs.document());
     }
 
     @Test
     @DisplayName("토픽 병합 생성")
     void mergeAndCreate() throws Exception {
         given(topicCommandService.merge(any(), any())).willReturn(1L);
-
-        MultiValueMap<String, Object> param = new LinkedMultiValueMap<>();
-
 
         TopicMergeRequestWithoutImage request = new TopicMergeRequestWithoutImage(
                 "준팍의 안갈집",
@@ -109,26 +93,25 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
                 PermissionType.ALL_MEMBERS,
                 List.of(1L, 2L, 3L)
         );
+        MockMultipartFile requestJson = new MockMultipartFile("request", "request", APPLICATION_JSON_VALUE,
+                objectMapper.writeValueAsBytes(request));
+        MockMultipartFile image = new MockMultipartFile("image", "test.png", IMAGE_PNG_VALUE, "data".getBytes());
 
-        param.add("image", mockFile);
-        param.add("request", request);
-
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/topics/merge")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-                        .contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
-                        .content(objectMapper.writeValueAsString(param))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.multipart(POST, "/topics/merge")
+                        .file(image)
+                        .file(requestJson)
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andDo(restDocs.document());
     }
 
     @Test
     @DisplayName("핀을 권한이 있는 토픽에 복사할 수 있다.")
     void copyPin() throws Exception {
-
-        mockMvc.perform(
-                MockMvcRequestBuilders.post("/topics/1/copy?pinIds=1,2,3")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.post("/topics/1/copy?pinIds=1,2,3")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -142,21 +125,21 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
                 PermissionType.ALL_MEMBERS
         );
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.put("/topics/1")
+        mockMvc.perform(MockMvcRequestBuilders.put("/topics/1")
                         .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(topicUpdateRequest))
-        ).andDo(restDocs.document());
+                        .content(objectMapper.writeValueAsString(topicUpdateRequest)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
     @DisplayName("토픽 삭제")
     void delete() throws Exception {
-        mockMvc.perform(
-                MockMvcRequestBuilders.delete("/topics/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.delete("/topics/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isNoContent())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -164,10 +147,10 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
     void findAll() throws Exception {
         given(topicQueryService.findAllReadable(any())).willReturn(RESPONSES);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/topics")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/topics")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -207,10 +190,10 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
         );
         given(topicQueryService.findDetailById(any(), any())).willReturn(topicDetailResponse);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/topics/1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/topics/1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -218,10 +201,10 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
     void findAllByOrderByUpdatedAtDesc() throws Exception {
         given(topicQueryService.findAllByOrderByUpdatedAtDesc(any())).willReturn(RESPONSES);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/topics/newest")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/topics/newest")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -229,10 +212,10 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
     void findAllTopicsByMemberId() throws Exception {
         given(topicQueryService.findAllTopicsByMemberId(any(), any())).willReturn(RESPONSES);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/topics/members?id=1")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/topics/members?id=1")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
     @Test
@@ -240,10 +223,10 @@ class TopicControllerTest extends RestDocsIntegration { // TODO: 2023/07/25 Imag
     void findAllBestTopics() throws Exception {
         given(topicQueryService.findAllBestTopics(any())).willReturn(RESPONSES);
 
-        mockMvc.perform(
-                MockMvcRequestBuilders.get("/topics/bests")
-                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L))
-        ).andDo(restDocs.document());
+        mockMvc.perform(MockMvcRequestBuilders.get("/topics/bests")
+                        .header(AUTHORIZATION, testAuthHeaderProvider.createAuthHeaderById(1L)))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(restDocs.document());
     }
 
 }


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
모든 RestDocs 테스트 코드

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
### 기존 명세서에 올라와있던 500 응답이 나오는 API들
- [x] [토픽 생성](https://mapbefine.kro.kr/api/docs/index.html#_%ED%86%A0%ED%94%BD_%EC%83%9D%EC%84%B1)
- [x] [토픽 병합](https://mapbefine.kro.kr/api/docs/index.html#_%ED%86%A0%ED%94%BD_%EB%B3%91%ED%95%A9)
- [x] [핀 생성](https://mapbefine.kro.kr/api/docs/index.html#_%ED%95%80_%EC%83%9D%EC%84%B1)
- [x] [핀 이미지 추가](https://mapbefine.kro.kr/api/docs/index.html#_%ED%95%80_%EC%9D%B4%EB%AF%B8%EC%A7%80_%EC%B6%94%EA%B0%80)
- [x] [회원의 내 정보 수정](https://mapbefine.kro.kr/api/docs/index.html#_%ED%9A%8C%EC%9B%90%EC%9D%98_%EB%82%B4_%EC%A0%95%EB%B3%B4_%EC%88%98%EC%A0%95)
- [x] [로그아웃](https://mapbefine.kro.kr/api/docs/index.html#_%EB%A1%9C%EA%B7%B8%EC%95%84%EC%9B%83)

### 그 외
- 모든 테스트 코드에 상태 코드 검증 조건을 추가했습니다. (`.andExpect()`) 기존에 이 조건이 없었어서 상태코드가 500이어도 테스트가 통과하는 문제가 있었습니다. **RestDocs 테스트 추가 작성 시 참고 부탁드립니다.**
- 이 과정에서 명세서에는 올려놓지 않았더라도 실패가 확인된 테스트들을 모두 수정했습니다.
   - 이제 이미지 명세도 RestDocs 명세서에서 확인 가능합니다.
   - LoginControllerTest의 실패 원인은 MockMvcTest 상의 쿠키 설정이었습니다. (해당 커밋 바디 참조)
- ControllerTest에서 관리자 인증 방식 내용을 반영하여, 관리자 API 명세서를 다시 활성화했습니다.
- 내부 로직이 불완전해 사용되면 안되는 API들을 adoc만 삭제했습니다. (Topic 삭제, Pin 삭제)

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
closed #563

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
