### PR TITLE
[FE] Refactor/#613 지도 클러스터링 기능 추가 및 지도 상태 리팩토링

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
     'no-unused-expressions': 'off',
     'react/jsx-props-no-spreading': 'off',
     'react/no-unused-prop-types': 'off',
-    'import/no-extraneous-dependencies': 'off',
+    'no-underscore-dangle': 'off',
   },
   settings: {
     'import/resolver': {

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -23,7 +23,6 @@ const getZoomMinLimit = () => {
 
 function Map() {
   const { Tmapv3 } = window;
-
   const { markers } = useContext(MarkerContext);
   const { width } = useContext(LayoutWidthContext);
   const { mapInstance, setMapInstance } = useMapStore((state) => state);

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -47,26 +47,25 @@ function Map() {
     const map = new Tmapv3.Map(mapContainer.current, {
       center: new Tmapv3.LatLng(37.5154, 127.1029),
       scaleBar: false,
+      width: '100%',
+      height: '100%',
     });
-
-    if (!map) return;
 
     map.setZoomLimit(getZoomMinLimit(), 17);
 
     setMapInstance(map);
 
-    // eslint-disable-next-line consistent-return
     return () => {
       map.destroy();
     };
   }, []);
 
-  useMapClick(mapInstance);
-  useClickedCoordinate(mapInstance);
-  useUpdateCoordinates(mapInstance);
+  useMapClick();
+  useClickedCoordinate();
+  useUpdateCoordinates();
 
-  useFocusToMarker(mapInstance, markers);
-  onFocusClickedPin(mapInstance, markers);
+  useFocusToMarker(markers);
+  onFocusClickedPin(markers);
 
   return (
     <MapContainer>
@@ -84,6 +83,8 @@ function Map() {
 }
 
 const MapContainer = styled.div`
+  width: 100%;
+  height: 100%;
   position: relative;
 `;
 

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -64,7 +64,7 @@ function Map() {
   useUpdateCoordinates();
 
   useFocusToMarker(markers);
-  onFocusClickedPin(markers);
+  onFocusClickedPin();
 
   return (
     <MapContainer>

--- a/frontend/src/components/common/Flex/index.ts
+++ b/frontend/src/components/common/Flex/index.ts
@@ -1,8 +1,11 @@
 import { styled } from 'styled-components';
 
-import Box, { BoxProps } from '../Box';
+import theme from '../../../themes';
+import { colorThemeKey } from '../../../themes/color';
+import { radiusKey } from '../../../themes/radius';
+import { SpaceThemeKeys } from '../../../themes/spacing';
 
-interface FlexProps extends BoxProps {
+interface FlexProps {
   $flexDirection?: string;
   $flexWrap?: string;
   $flexBasis?: string;
@@ -14,9 +17,34 @@ interface FlexProps extends BoxProps {
   $justifyItems?: string;
   flex?: string;
   $gap?: string;
+
+  width?: string;
+  height?: string;
+  $minWidth?: string;
+  $minHeight?: string;
+  $maxWidth?: string;
+  $maxHeight?: string;
+  padding?: SpaceThemeKeys | string;
+  $backgroundColor?: colorThemeKey;
+  $backdropFilter?: string;
+  overflow?: string;
+  color?: colorThemeKey;
+  position?: string;
+  right?: string;
+  top?: string;
+  left?: string;
+  bottom?: string;
+  $borderRadius?: radiusKey;
+  $borderTop?: string;
+  $borderRight?: string;
+  $borderBottom?: string;
+  $borderLeft?: string;
+  cursor?: string;
+  opacity?: string;
+  $zIndex?: number;
 }
 
-const Flex = styled(Box)<FlexProps>`
+const Flex = styled.div<FlexProps>`
   display: flex;
   flex-direction: ${({ $flexDirection }) => $flexDirection};
   flex-wrap: ${({ $flexWrap }) => $flexWrap};
@@ -29,6 +57,39 @@ const Flex = styled(Box)<FlexProps>`
   justify-items: ${({ $justifyItems }) => $justifyItems};
   flex: ${({ flex }) => flex};
   gap: ${({ $gap }) => $gap};
+
+  background-color: ${({ $backgroundColor }) =>
+    $backgroundColor && theme.color[$backgroundColor]};
+  backdrop-filter: ${({ $backdropFilter }) => $backdropFilter};
+  color: ${({ color }) => color && theme.color[color]};
+  padding: ${({ padding }) => padding && convertPadding(padding)};
+  width: ${({ width }) => width};
+  height: ${({ height }) => height};
+  min-width: ${({ $minWidth }) => $minWidth};
+  min-height: ${({ $minHeight }) => $minHeight};
+  max-width: ${({ $maxWidth }) => $maxWidth};
+  max-height: ${({ $maxHeight }) => $maxHeight};
+  overflow: ${({ overflow }) => overflow};
+  position: ${({ position }) => position};
+  right: ${({ right }) => right};
+  top: ${({ top }) => top};
+  left: ${({ left }) => left};
+  bottom: ${({ bottom }) => bottom};
+  border-radius: ${({ $borderRadius }) =>
+    $borderRadius && theme.radius[$borderRadius]};
+  border-top: ${({ $borderTop }) => $borderTop};
+  border-right: ${({ $borderRight }) => $borderRight};
+  border-bottom: ${({ $borderBottom }) => $borderBottom};
+  border-left: ${({ $borderLeft }) => $borderLeft};
+  cursor: ${({ cursor }) => cursor};
+  opacity: ${({ opacity }) => opacity};
+  z-index: ${({ $zIndex }) => $zIndex};
 `;
+
+const convertPadding = (padding: SpaceThemeKeys | string) => {
+  if (typeof padding === 'string' && padding.length > 1) return padding;
+
+  return theme.spacing[Number(padding)];
+};
 
 export default Flex;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -11,3 +11,5 @@ export const DEFAULT_PROFILE_IMAGE =
 
 export const DEFAULT_PROD_URL =
   process.env.APP_URL || 'https://mapbefine.kro.kr/api';
+
+export const PIN_SIZE = 60;

--- a/frontend/src/constants/pinImage.ts
+++ b/frontend/src/constants/pinImage.ts
@@ -83,3 +83,25 @@ export const pinColors: PinImageMap = {
   6: '#FD842D',
   7: '#C340B6',
 };
+
+const showExpendedPopUp = () => {
+  const infoWindow = document.querySelector('.info-window-default');
+};
+
+export const getInfoWindowTemplate = ({
+  backgroundColor,
+  pinName,
+  pinLength,
+}: {
+  backgroundColor: string;
+  pinName: string;
+  pinLength: number;
+}) => `
+<div class="info-window-default" onclick="" style="position: relative; padding: 4px 12px; display:flex; border-radius: 20px; justify-content: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${backgroundColor};">
+${pinName}
+${
+  pinLength > 1 &&
+  `<div style="position: absolute; top: -16px; right: -12px; padding: 2px 4px; font-size: 14px; background-color: #fff; border-radius: 4px; border: 1px solid ${backgroundColor}; color: ${backgroundColor}"> + ${pinLength}</div>`
+}
+</div>
+`;

--- a/frontend/src/constants/pinImage.ts
+++ b/frontend/src/constants/pinImage.ts
@@ -84,24 +84,39 @@ export const pinColors: PinImageMap = {
   7: '#C340B6',
 };
 
-const showExpendedPopUp = () => {
-  const infoWindow = document.querySelector('.info-window-default');
-};
-
 export const getInfoWindowTemplate = ({
   backgroundColor,
   pinName,
-  pinLength,
+  pins,
+  condition,
 }: {
   backgroundColor: string;
   pinName: string;
-  pinLength: number;
+  pins: [];
+  condition: number;
 }) => `
-<div class="info-window-default" onclick="" style="position: relative; padding: 4px 12px; display:flex; border-radius: 20px; justify-content: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${backgroundColor};">
-${pinName}
+<div style="position: relative;">
 ${
-  pinLength > 1 &&
-  `<div style="position: absolute; top: -16px; right: -12px; padding: 2px 4px; font-size: 14px; background-color: #fff; border-radius: 4px; border: 1px solid ${backgroundColor}; color: ${backgroundColor}"> + ${pinLength}</div>`
+  condition !== 1
+    ? pins
+        .map(
+          (
+            pin: any,
+          ) => `<div style="border-bottom: 1px solid white; padding: 4px 12px; display:flex; border-radius: 20px; justify-content: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${backgroundColor};">
+  ${pin.name}
+  </div>`,
+        )
+        .join('')
+    : `<div style="padding: 4px 12px; display:flex; border-radius: 20px; justify-content: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${backgroundColor};">
+  ${pinName}
+  </div>
+  ${
+    pins.length > 1
+      ? `
+      <div style="position: absolute; top: -14px; right: -12px; padding: 2px 4px; font-size: 14px; background-color: #fff; border-radius: 50%; border: 1px solid ${backgroundColor}; color: ${backgroundColor}">+${pins.length}</div>
+      `
+      : ''
+  }
+  </div>`
 }
-</div>
 `;

--- a/frontend/src/constants/pinImage.ts
+++ b/frontend/src/constants/pinImage.ts
@@ -9,7 +9,7 @@ export const USER_LOCATION_IMAGE = `<svg width="24" height="24" viewBox="0 0 24 
 `;
 
 export const pinImageMap: PinImageMap = {
-  1: `<svg width="40" height="58" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  1: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#E1325C"/>
 <circle cx="17.7548" cy="8.88856" r="3.55556" fill="white" fill-opacity="0.6"/>
@@ -18,7 +18,7 @@ export const pinImageMap: PinImageMap = {
 <circle cx="27.0872" cy="17.3333" r="1.33333" fill="black"/>
 </svg>
 `,
-  2: `<svg width="40" height="58" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  2: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#F9CB55"/>
 <circle cx="17.7548" cy="8.88856" r="3.55556" fill="white" fill-opacity="0.6"/>
@@ -27,7 +27,7 @@ export const pinImageMap: PinImageMap = {
 <circle cx="27.0872" cy="17.3333" r="1.33333" fill="black"/>
 </svg>
 `,
-  3: `<svg width="40" height="58" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  3: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#4B5CFA"/>
 <circle cx="17.7548" cy="8.88856" r="3.55556" fill="white" fill-opacity="0.6"/>
@@ -36,7 +36,7 @@ export const pinImageMap: PinImageMap = {
 <circle cx="27.0872" cy="17.3333" r="1.33333" fill="black"/>
 </svg>
 `,
-  4: `<svg width="40" height="58" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  4: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#57B148"/>
 <circle cx="17.7548" cy="8.88856" r="3.55556" fill="white" fill-opacity="0.6"/>
@@ -45,7 +45,7 @@ export const pinImageMap: PinImageMap = {
 <circle cx="27.0872" cy="17.3333" r="1.33333" fill="black"/>
 </svg>
 `,
-  5: `<svg width="40" height="58" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  5: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#2AC1BC"/>
 <circle cx="17.7548" cy="8.88856" r="3.55556" fill="white" fill-opacity="0.6"/>
@@ -54,7 +54,7 @@ export const pinImageMap: PinImageMap = {
 <circle cx="27.0872" cy="17.3333" r="1.33333" fill="black"/>
 </svg>
 `,
-  6: `<svg width="40" height="58" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  6: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#FD842D"/>
 <circle cx="17.7548" cy="8.88856" r="3.55556" fill="white" fill-opacity="0.6"/>
@@ -63,7 +63,7 @@ export const pinImageMap: PinImageMap = {
 <circle cx="27.0872" cy="17.3333" r="1.33333" fill="black"/>
 </svg>
 `,
-  7: `<svg width="40" height="58" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
+  7: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#C340B6"/>
 <circle cx="17.7548" cy="8.88856" r="3.55556" fill="white" fill-opacity="0.6"/>

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -1,7 +1,11 @@
 import { createContext, useContext, useState } from 'react';
 import { useLocation, useParams } from 'react-router-dom';
 
-import { pinColors, pinImageMap } from '../constants/pinImage';
+import {
+  getInfoWindowTemplate,
+  pinColors,
+  pinImageMap,
+} from '../constants/pinImage';
 import useNavigator from '../hooks/useNavigator';
 import useMapStore from '../store/mapInstance';
 import useMapSidebarCoordinates from '../store/mapSidebarCoordinates';
@@ -140,13 +144,16 @@ function MarkerProvider({ children }: Props): JSX.Element {
         position: new Tmapv3.LatLng(coordinate.latitude, coordinate.longitude),
         border: 0,
         background: 'transparent',
-        content: `<div style="padding: 4px 12px; display:flex; border-radius: 20px; justify-contents: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${
-          pinColors[markerType + 1]
-        };">${coordinate.pinName}</div>`,
-        offset: new Tmapv3.Point(0, -60),
+        content: getInfoWindowTemplate({
+          backgroundColor: pinColors[markerType + 1],
+          pinName: coordinate.pinName,
+          pinLength: coordinate.pins.length,
+        }),
+        offset: new Tmapv3.Point(0, -64),
         type: 2,
         map: mapInstance,
       });
+
       return infoWindow;
     });
 

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -96,6 +96,7 @@ function MarkerProvider({ children }: Props): JSX.Element {
         routePage(`/see-together/${topicId}?pinDetail=${marker.id}`);
       });
     });
+
     setMarkers(newMarkers);
   };
 

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -10,11 +10,11 @@ import { Coordinate, CoordinatesContext } from './CoordinatesContext';
 type MarkerContextType = {
   markers: Marker[];
   clickedMarker: Marker | null;
-  createMarkers: (map: TMap) => void;
+  createMarkers: () => void;
   removeMarkers: () => void;
   removeInfowindows: () => void;
-  createInfowindows: (map: TMap) => void;
-  displayClickedMarker: (map: TMap) => void;
+  createInfowindows: () => void;
+  displayClickedMarker: () => void;
 };
 
 const defaultMarkerContext = () => {
@@ -65,19 +65,15 @@ function MarkerProvider({ children }: Props): JSX.Element {
     return coordinatesInScreenSize;
   };
 
-  const createMarker = (
-    coordinate: Coordinate,
-    map: TMap,
-    markerType: number,
-  ) =>
+  const createMarker = (coordinate: Coordinate, markerType: number) =>
     new Tmapv3.Marker({
       position: new Tmapv3.LatLng(coordinate.latitude, coordinate.longitude),
       iconHTML: pinImageMap[markerType + 1],
-      map,
+      map: mapInstance,
     });
 
   // 현재 클릭된 좌표의 마커 생성
-  const displayClickedMarker = (map: TMap) => {
+  const displayClickedMarker = () => {
     if (clickedMarker) {
       clickedMarker.setMap(null);
     }
@@ -87,14 +83,14 @@ function MarkerProvider({ children }: Props): JSX.Element {
         clickedCoordinate.longitude,
       ),
       icon: 'http://tmapapi.sktelecom.com/upload/tmap/marker/pin_g_m_m.png',
-      map,
+      map: mapInstance,
     });
     marker.id = 'clickedMarker';
     setClickedMarker(marker);
   };
 
   // coordinates를 받아서 marker를 생성하고, marker를 markers 배열에 추가
-  const createMarkers = (map: TMap) => {
+  const createMarkers = () => {
     let markerType = -1;
     let currentTopicId = '-1';
 
@@ -107,7 +103,7 @@ function MarkerProvider({ children }: Props): JSX.Element {
         markerType = (markerType + 1) % 7;
         currentTopicId = coordinate.topicId;
       }
-      const marker = createMarker(coordinate, map, markerType);
+      const marker = createMarker(coordinate, markerType);
       marker.id = String(coordinate.id);
       return marker;
     });
@@ -126,7 +122,7 @@ function MarkerProvider({ children }: Props): JSX.Element {
     setMarkers(newMarkers);
   };
 
-  const createInfowindows = (map: TMap) => {
+  const createInfowindows = () => {
     let markerType = -1;
     let currentTopicId = '-1';
 
@@ -149,7 +145,7 @@ function MarkerProvider({ children }: Props): JSX.Element {
         };">${coordinate.pinName}</div>`,
         offset: new Tmapv3.Point(0, -60),
         type: 2,
-        map,
+        map: mapInstance,
       });
       return infoWindow;
     });

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -8,7 +8,6 @@ import {
 } from '../constants/pinImage';
 import useNavigator from '../hooks/useNavigator';
 import useMapStore from '../store/mapInstance';
-import useMapSidebarCoordinates from '../store/mapSidebarCoordinates';
 import { Coordinate, CoordinatesContext } from './CoordinatesContext';
 
 type MarkerContextType = {
@@ -46,7 +45,6 @@ function MarkerProvider({ children }: Props): JSX.Element {
   const [infoWindows, setInfoWindows] = useState<InfoWindow[] | null>(null);
   const [clickedMarker, setClickedMarker] = useState<Marker | null>(null);
   const { coordinates, clickedCoordinate } = useContext(CoordinatesContext);
-  const { sidebarCoordinates } = useMapSidebarCoordinates((state) => state);
   const { topicId } = useParams<{ topicId: string }>();
   const { routePage } = useNavigator();
   const { pathname } = useLocation();

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -126,6 +126,16 @@ function MarkerProvider({ children }: Props): JSX.Element {
     setMarkers(newMarkers);
   };
 
+  const getCondition = (pins: any) => {
+    if (!mapInstance) return;
+
+    if (mapInstance.getZoom() === 17 && pins.length > 1) {
+      return pins.length;
+    }
+
+    return 1;
+  };
+
   const createInfowindows = () => {
     let markerType = -1;
     let currentTopicId = '-1';
@@ -147,7 +157,8 @@ function MarkerProvider({ children }: Props): JSX.Element {
         content: getInfoWindowTemplate({
           backgroundColor: pinColors[markerType + 1],
           pinName: coordinate.pinName,
-          pinLength: coordinate.pins.length,
+          pins: coordinate.pins,
+          condition: getCondition(coordinate.pins),
         }),
         offset: new Tmapv3.Point(0, -64),
         type: 2,
@@ -166,7 +177,9 @@ function MarkerProvider({ children }: Props): JSX.Element {
   };
 
   const removeInfowindows = () => {
-    infoWindows?.forEach((infoWindow: InfoWindow) => infoWindow.setMap(null));
+    infoWindows?.forEach((infoWindow: InfoWindow) => {
+      infoWindow.setMap(null);
+    });
     setInfoWindows([]);
   };
 

--- a/frontend/src/hooks/useAnimateClickedPin.ts
+++ b/frontend/src/hooks/useAnimateClickedPin.ts
@@ -1,24 +1,38 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 
+import { CoordinatesContext } from '../context/CoordinatesContext';
+import { MarkerContext } from '../context/MarkerContext';
 import useMapStore from '../store/mapInstance';
 
 const useAnimateClickedPin = () => {
+  const { Tmapv3 } = window;
   const queryParams = new URLSearchParams(location.search);
   const { mapInstance } = useMapStore((state) => state);
   const [checkQueryParams, setCheckQueryParams] = useState<any>(queryParams);
+  const { coordinates } = useContext(CoordinatesContext);
+  const { removeMarkers, removeInfowindows, createMarkers, createInfowindows } =
+    useContext(MarkerContext);
 
-  const onFocusClickedPin = (markers: Marker[]) => {
+  const onFocusClickedPin = () => {
     useEffect(() => {
       const currentQueryParams = new URLSearchParams(location.search);
 
+      // TODO : 이 부분 로직 검토해보기
       if (checkQueryParams === null) {
         if (!mapInstance) return;
         const pinId = queryParams.get('pinDetail');
-        const marker = markers.find((marker: Marker) => marker.id === pinId);
+        const clickedMarker = coordinates
+          .map((pin: any) => {
+            if (pin.pins.map((pin: any) => pin.id).includes(Number(pinId))) {
+              return new Tmapv3.LatLng(pin.latitude, pin.longitude);
+            }
+            return null;
+          })
+          .find((latLng) => latLng);
 
-        if (!marker) return;
+        if (!clickedMarker) return;
 
-        mapInstance.setCenter(marker.getPosition());
+        mapInstance.setCenter(clickedMarker);
 
         setCheckQueryParams(currentQueryParams);
         return;
@@ -29,16 +43,27 @@ const useAnimateClickedPin = () => {
         currentQueryParams.get('pinDetail')
       ) {
         const pinId = queryParams.get('pinDetail');
-        const marker = markers.find((marker: Marker) => marker.id === pinId);
+        const clickedMarker = coordinates
+          .map((pin: any) => {
+            if (pin.pins.map((pin: any) => pin.id).includes(Number(pinId))) {
+              return new Tmapv3.LatLng(pin.latitude, pin.longitude);
+            }
+            return null;
+          })
+          .find((latLng) => latLng);
 
-        if (marker && mapInstance) {
-          mapInstance.setCenter(marker.getPosition());
+        if (clickedMarker && mapInstance) {
+          removeMarkers();
+          removeInfowindows();
+          mapInstance.setCenter(clickedMarker);
           mapInstance.setZoom(17);
+          createMarkers();
+          createInfowindows();
         }
 
         setCheckQueryParams(currentQueryParams);
       }
-    }, [markers, mapInstance, queryParams]);
+    }, [coordinates, mapInstance, queryParams.get('pinDetail')]);
   };
 
   return { checkQueryParams, onFocusClickedPin };

--- a/frontend/src/hooks/useAnimateClickedPin.ts
+++ b/frontend/src/hooks/useAnimateClickedPin.ts
@@ -52,6 +52,7 @@ const useAnimateClickedPin = () => {
           })
           .find((latLng) => latLng);
 
+        // TODO: useUpdateCoordinates 훅이랑 실행 순서 차이로 인한 업데이트 오류 있는 듯 보임. 이 훅은 sidebar 전용으로 만들어볼 것
         if (clickedMarker && mapInstance) {
           removeMarkers();
           removeInfowindows();

--- a/frontend/src/hooks/useAnimateClickedPin.ts
+++ b/frontend/src/hooks/useAnimateClickedPin.ts
@@ -1,21 +1,24 @@
 import { useEffect, useState } from 'react';
 
+import useMapStore from '../store/mapInstance';
+
 const useAnimateClickedPin = () => {
   const queryParams = new URLSearchParams(location.search);
+  const { mapInstance } = useMapStore((state) => state);
   const [checkQueryParams, setCheckQueryParams] = useState<any>(queryParams);
 
-  const onFocusClickedPin = (map: TMap | null, markers: Marker[]) => {
+  const onFocusClickedPin = (markers: Marker[]) => {
     useEffect(() => {
       const currentQueryParams = new URLSearchParams(location.search);
 
       if (checkQueryParams === null) {
-        if (!map) return;
+        if (!mapInstance) return;
         const pinId = queryParams.get('pinDetail');
         const marker = markers.find((marker: Marker) => marker.id === pinId);
 
         if (!marker) return;
 
-        map.setCenter(marker.getPosition());
+        mapInstance.setCenter(marker.getPosition());
 
         setCheckQueryParams(currentQueryParams);
         return;
@@ -28,13 +31,14 @@ const useAnimateClickedPin = () => {
         const pinId = queryParams.get('pinDetail');
         const marker = markers.find((marker: Marker) => marker.id === pinId);
 
-        if (marker && map) {
-          map.setCenter(marker.getPosition());
-          map.setZoom(17);
+        if (marker && mapInstance) {
+          mapInstance.setCenter(marker.getPosition());
+          mapInstance.setZoom(17);
         }
+
         setCheckQueryParams(currentQueryParams);
       }
-    }, [markers, map, queryParams]);
+    }, [markers, mapInstance, queryParams]);
   };
 
   return { checkQueryParams, onFocusClickedPin };

--- a/frontend/src/hooks/useClickedCoordinate.ts
+++ b/frontend/src/hooks/useClickedCoordinate.ts
@@ -2,24 +2,22 @@ import { useContext, useEffect } from 'react';
 
 import { CoordinatesContext } from '../context/CoordinatesContext';
 import { MarkerContext } from '../context/MarkerContext';
+import useMapStore from '../store/mapInstance';
 
-export default function useClickedCoordinate(map: TMap | null) {
+export default function useClickedCoordinate() {
   const { Tmapv3 } = window;
+  const { mapInstance } = useMapStore((state) => state);
   const { clickedCoordinate } = useContext(CoordinatesContext);
   const { displayClickedMarker } = useContext(MarkerContext);
 
   useEffect(() => {
-    if (!map) return;
-    const currentZoom = map.getZoom();
-    if (clickedCoordinate.address) displayClickedMarker(map);
+    if (!mapInstance) return;
+    const currentZoom = mapInstance.getZoom();
+    if (clickedCoordinate.address) displayClickedMarker(mapInstance);
 
     // 선택된 좌표가 있으면 해당 좌표로 지도의 중심을 이동
     if (clickedCoordinate.latitude && clickedCoordinate.longitude) {
-      if (currentZoom <= 17) {
-        map.setZoom(17);
-      }
-
-      map.panTo(
+      mapInstance.panTo(
         new Tmapv3.LatLng(
           clickedCoordinate.latitude,
           clickedCoordinate.longitude,

--- a/frontend/src/hooks/useFocusToMarkers.ts
+++ b/frontend/src/hooks/useFocusToMarkers.ts
@@ -1,15 +1,18 @@
 import { useEffect, useRef, useState } from 'react';
 
-const useFocusToMarker = (map: TMap | null, markers: Marker[]) => {
+import useMapStore from '../store/mapInstance';
+
+const useFocusToMarker = (markers: Marker[]) => {
   const { Tmapv3 } = window;
+  const { mapInstance } = useMapStore((state) => state);
   const bounds = useRef(new Tmapv3.LatLngBounds());
   const [markersLength, setMarkersLength] = useState<Number>(0);
 
   useEffect(() => {
-    if (map && markers && markers.length === 1) {
-      map.panTo(markers[0].getPosition());
+    if (mapInstance && markers && markers.length === 1) {
+      mapInstance.panTo(markers[0].getPosition());
     }
-    if (map && markers && markers.length > 1) {
+    if (mapInstance && markers && markers.length > 1) {
       bounds.current = new Tmapv3.LatLngBounds();
       markers.forEach((marker: Marker) => {
         bounds.current.extend(marker.getPosition());
@@ -17,11 +20,32 @@ const useFocusToMarker = (map: TMap | null, markers: Marker[]) => {
 
       if (markersLength === 0) {
         setMarkersLength(markers.length);
-        map.fitBounds(bounds.current);
+
+        const mapBounds = mapInstance.getBounds();
+
+        const leftWidth = new Tmapv3.LatLng(
+          mapBounds._ne._lat,
+          mapBounds._sw._lng,
+        );
+        const rightWidth = new Tmapv3.LatLng(
+          mapBounds._ne._lat,
+          mapBounds._ne._lng,
+        );
+        console.log(leftWidth.distanceTo(rightWidth));
+
+        mapInstance.setCenter(bounds.current.getCenter());
+        // map.fitBounds(bounds.current, {
+        //   left: 100, // 지도의 왼쪽과의 간격(단위 : px)
+        //   top: 100, // 지도의 위쪽과의 간격(단위 : px)
+        //   right: 100, // 지도의 오른쪽과의 간격(단위 : px)
+        //   bottom: 20, // 지도의 아래쪽과의 간격(단위 : px)
+        // });
         return;
       }
 
-      if (markersLength !== markers.length) map.fitBounds(bounds.current);
+      if (markersLength !== markers.length) {
+        mapInstance.fitBounds(bounds.current);
+      }
     }
     return () => {
       setMarkersLength(0);

--- a/frontend/src/hooks/useFocusToMarkers.ts
+++ b/frontend/src/hooks/useFocusToMarkers.ts
@@ -10,7 +10,7 @@ const useFocusToMarker = (markers: Marker[]) => {
 
   useEffect(() => {
     if (mapInstance && markers && markers.length === 1) {
-      mapInstance.panTo(markers[0].getPosition());
+      // mapInstance.panTo(markers[0].getPosition());
     }
     if (mapInstance && markers && markers.length > 1) {
       bounds.current = new Tmapv3.LatLngBounds();
@@ -21,19 +21,8 @@ const useFocusToMarker = (markers: Marker[]) => {
       if (markersLength === 0) {
         setMarkersLength(markers.length);
 
-        const mapBounds = mapInstance.getBounds();
+        // mapInstance.setCenter(bounds.current.getCenter());
 
-        const leftWidth = new Tmapv3.LatLng(
-          mapBounds._ne._lat,
-          mapBounds._sw._lng,
-        );
-        const rightWidth = new Tmapv3.LatLng(
-          mapBounds._ne._lat,
-          mapBounds._ne._lng,
-        );
-        console.log(leftWidth.distanceTo(rightWidth));
-
-        mapInstance.setCenter(bounds.current.getCenter());
         // map.fitBounds(bounds.current, {
         //   left: 100, // 지도의 왼쪽과의 간격(단위 : px)
         //   top: 100, // 지도의 위쪽과의 간격(단위 : px)
@@ -44,7 +33,7 @@ const useFocusToMarker = (markers: Marker[]) => {
       }
 
       if (markersLength !== markers.length) {
-        mapInstance.fitBounds(bounds.current);
+        // mapInstance.fitBounds(bounds.current);
       }
     }
     return () => {

--- a/frontend/src/hooks/useFocusToMarkers.ts
+++ b/frontend/src/hooks/useFocusToMarkers.ts
@@ -9,10 +9,7 @@ const useFocusToMarker = (markers: Marker[]) => {
   const [markersLength, setMarkersLength] = useState<Number>(0);
 
   useEffect(() => {
-    if (mapInstance && markers && markers.length === 1) {
-      // mapInstance.panTo(markers[0].getPosition());
-    }
-    if (mapInstance && markers && markers.length > 1) {
+    if (mapInstance && markers && markers.length >= 1) {
       bounds.current = new Tmapv3.LatLngBounds();
       markers.forEach((marker: Marker) => {
         bounds.current.extend(marker.getPosition());
@@ -23,7 +20,7 @@ const useFocusToMarker = (markers: Marker[]) => {
 
         // mapInstance.setCenter(bounds.current.getCenter());
 
-        // map.fitBounds(bounds.current, {
+        // mapInstance.fitBounds(bounds.current, {
         //   left: 100, // 지도의 왼쪽과의 간격(단위 : px)
         //   top: 100, // 지도의 위쪽과의 간격(단위 : px)
         //   right: 100, // 지도의 오른쪽과의 간격(단위 : px)

--- a/frontend/src/hooks/useMapClick.ts
+++ b/frontend/src/hooks/useMapClick.ts
@@ -34,7 +34,7 @@ export default function useMapClick() {
 
     return () => {
       if (mapInstance) {
-        mapInstance.removeListener('click', clickHandler);
+        mapInstance.off('Click', clickHandler);
       }
     };
   }, [mapInstance]);

--- a/frontend/src/hooks/useMapClick.ts
+++ b/frontend/src/hooks/useMapClick.ts
@@ -2,11 +2,13 @@ import { useContext, useEffect } from 'react';
 
 import { CoordinatesContext } from '../context/CoordinatesContext';
 import getAddressFromServer from '../lib/getAddressFromServer';
+import useMapStore from '../store/mapInstance';
 import useToast from './useToast';
 
-export default function useMapClick(map: TMap | null) {
+export default function useMapClick() {
   const { setClickedCoordinate } = useContext(CoordinatesContext);
   const { showToast } = useToast();
+  const { mapInstance } = useMapStore((state) => state);
 
   const clickHandler = async (evt: evt) => {
     try {
@@ -26,14 +28,14 @@ export default function useMapClick(map: TMap | null) {
   };
 
   useEffect(() => {
-    if (!map) return;
+    if (!mapInstance) return;
 
-    map.on('Click', clickHandler);
+    mapInstance.on('Click', clickHandler);
 
     return () => {
-      if (map) {
-        map.removeListener('click', clickHandler);
+      if (mapInstance) {
+        mapInstance.removeListener('click', clickHandler);
       }
     };
-  }, [map]);
+  }, [mapInstance]);
 }

--- a/frontend/src/hooks/useUpdateCoordinates.ts
+++ b/frontend/src/hooks/useUpdateCoordinates.ts
@@ -2,11 +2,10 @@ import { useContext, useEffect } from 'react';
 
 import { CoordinatesContext } from '../context/CoordinatesContext';
 import { MarkerContext } from '../context/MarkerContext';
-import useMapStore from '../store/mapInstance';
+import useMapSidebarCoordinates from '../store/mapSidebarCoordinates';
 
 export default function useUpdateCoordinates() {
   const { coordinates } = useContext(CoordinatesContext);
-  const { mapInstance } = useMapStore((state) => state);
   const {
     markers,
     createMarkers,
@@ -15,17 +14,17 @@ export default function useUpdateCoordinates() {
     removeInfowindows,
   } = useContext(MarkerContext);
 
-  useEffect(() => {
-    if (!mapInstance) return;
+  const removePins = (markers: Marker[]) => {
+    removeMarkers();
+    removeInfowindows();
+  };
 
-    if (markers && markers.length > 0) {
-      removeMarkers();
-      removeInfowindows();
-    }
+  useEffect(() => {
+    removePins(markers);
 
     if (coordinates.length > 0) {
-      createMarkers(mapInstance);
-      createInfowindows(mapInstance);
+      createMarkers();
+      createInfowindows();
     }
   }, [coordinates]);
 }

--- a/frontend/src/hooks/useUpdateCoordinates.ts
+++ b/frontend/src/hooks/useUpdateCoordinates.ts
@@ -2,7 +2,6 @@ import { useContext, useEffect } from 'react';
 
 import { CoordinatesContext } from '../context/CoordinatesContext';
 import { MarkerContext } from '../context/MarkerContext';
-import useMapSidebarCoordinates from '../store/mapSidebarCoordinates';
 
 export default function useUpdateCoordinates() {
   const { coordinates } = useContext(CoordinatesContext);

--- a/frontend/src/hooks/useUpdateCoordinates.ts
+++ b/frontend/src/hooks/useUpdateCoordinates.ts
@@ -2,9 +2,11 @@ import { useContext, useEffect } from 'react';
 
 import { CoordinatesContext } from '../context/CoordinatesContext';
 import { MarkerContext } from '../context/MarkerContext';
+import useMapStore from '../store/mapInstance';
 
-export default function useUpdateCoordinates(map: TMap | null) {
+export default function useUpdateCoordinates() {
   const { coordinates } = useContext(CoordinatesContext);
+  const { mapInstance } = useMapStore((state) => state);
   const {
     markers,
     createMarkers,
@@ -14,14 +16,16 @@ export default function useUpdateCoordinates(map: TMap | null) {
   } = useContext(MarkerContext);
 
   useEffect(() => {
-    if (!map) return;
+    if (!mapInstance) return;
+
     if (markers && markers.length > 0) {
       removeMarkers();
       removeInfowindows();
     }
+
     if (coordinates.length > 0) {
-      createMarkers(map);
-      createInfowindows(map);
+      createMarkers(mapInstance);
+      createInfowindows(mapInstance);
     }
   }, [coordinates]);
 }

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -82,10 +82,7 @@ function SelectedTopic() {
       newCoordinates.push({
         topicId,
         id: clusterOrPin.pins[0].id || `cluster ${idx}`,
-        pinName:
-          clusterOrPin.pins.length > 1
-            ? `${clusterOrPin.pins[0].name} 💬 + ${clusterOrPin.pins.length} 개`
-            : clusterOrPin.pins[0].name,
+        pinName: clusterOrPin.pins[0].name,
         latitude: clusterOrPin.latitude,
         longitude: clusterOrPin.longitude,
         pins: clusterOrPin.pins,

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -73,7 +73,7 @@ function SelectedTopic() {
     const distanceOfPinSize = getDistanceOfPin();
 
     const diameterPins = await getApi<any>(
-      `/topics/clusters/ids?ids=${topicId}&image-diameter=${distanceOfPinSize}`,
+      `/topics/clusters?ids=${topicId}&image-diameter=${distanceOfPinSize}`,
     );
 
     diameterPins.forEach((clusterOrPin: any, idx: number) => {

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -93,7 +93,7 @@ function SelectedTopic() {
   };
 
   const setPrevCoordinates = () => {
-    setCoordinates([...coordinates]);
+    setCoordinates((prev) => [...prev]);
   };
 
   useEffect(() => {

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -72,11 +72,9 @@ function SelectedTopic() {
     const newCoordinates: any = [];
     const distanceOfPinSize = getDistanceOfPin();
 
-    // const diameterPins = await getApi<any>(
-    //   `/topics/clusters/ids?ids=${topicId}&image-diameter=${distanceOfPinSize}`,
-    // );
-
-    const diameterPins = 붕어빵지도;
+    const diameterPins = await getApi<any>(
+      `/topics/clusters/ids?ids=${topicId}&image-diameter=${distanceOfPinSize}`,
+    );
 
     diameterPins.forEach((clusterOrPin: any, idx: number) => {
       newCoordinates.push({

--- a/frontend/src/store/mapInstance.ts
+++ b/frontend/src/store/mapInstance.ts
@@ -1,11 +1,11 @@
 import { create } from 'zustand';
 
-interface MapState {
+interface MapContext {
   mapInstance: TMap | null;
   setMapInstance: (instance: TMap) => void;
 }
 
-const useMapStore = create<MapState>((set) => ({
+const useMapStore = create<MapContext>((set) => ({
   mapInstance: null,
   setMapInstance: (instance: TMap) => set(() => ({ mapInstance: instance })),
 }));

--- a/frontend/src/types/tmap.d.ts
+++ b/frontend/src/types/tmap.d.ts
@@ -33,6 +33,7 @@ interface TMap {
   resize(width: number, height: number): void;
   getBounds(): LatLngBounds;
   realToScreen(latLng: LatLng): Point;
+  off(eventType: string, callback: (event: evt) => void): void;
 }
 
 interface Marker {

--- a/frontend/src/types/tmap.d.ts
+++ b/frontend/src/types/tmap.d.ts
@@ -1,7 +1,14 @@
-interface LatLng {}
+interface LatLng {
+  _lat: number;
+  _lng: number;
+  distanceTo(latLng: LatLng): number;
+}
 
 interface LatLngBounds {
   extend(latLng: LatLng): void;
+  getCenter(): LatLng;
+  _ne: LatLng;
+  _sw: LatLng;
 }
 
 interface evt {
@@ -24,6 +31,7 @@ interface TMap {
   on(eventType: string, callback: (event: evt) => void): void;
   removeListener(eventType: string, callback: (event: evt) => void): void;
   resize(width: number, height: number): void;
+  getBounds(): LatLngBounds;
 }
 
 interface Marker {
@@ -58,7 +66,12 @@ interface Window {
   Tmapv3: {
     Map: new (
       element: HTMLElement,
-      options?: { center?: LatLng; scaleBar: boolean },
+      options?: {
+        center?: LatLng;
+        scaleBar: boolean;
+        width: string | number;
+        height: string | number;
+      },
     ) => TMap;
     LatLng: new (lat: number, lng: number) => LatLng;
     LatLngBounds: new () => LatLngBounds;

--- a/frontend/src/types/tmap.d.ts
+++ b/frontend/src/types/tmap.d.ts
@@ -32,6 +32,7 @@ interface TMap {
   removeListener(eventType: string, callback: (event: evt) => void): void;
   resize(width: number, height: number): void;
   getBounds(): LatLngBounds;
+  realToScreen(latLng: LatLng): Point;
 }
 
 interface Marker {


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
* Flex 공통 컴포넌트 interface 작업 (본문과는 관련없지만 에러 띄워진 상태가 지속되기에 리팩토링하였습니다.)
* 토픽 단일 조회 지도 클러스터링 (모아보기는 추후 진행)

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] Flex 공통 컴포넌트를 상속받은 로컬 스타일드 컴포넌트에 특정 타입을 제네릭으로 지정한 경우 발생하는 타입 오류 해결 (논의 필요)
- [x] mapInstance 전역 상태로 완전 분리 및 모든 지도 커스텀 훅에 적용
- [x] 지도에 dragEnd 및 zoomEnd 이벤트 등록
- [x] 핀 사이즈 60px로 고정
- [x] 토픽 단일 조회 페이지에 한하여 클러스터링 진행 및 클러스터링 디자인 적용
- [x] 최고 줌인 상태에서 클러스터링 되었을 경우 infoWindow로 모든 핀 표현

## 🙋🏻 세부 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
드디어 클러스터링을 완료했습니다. (단, 토픽 단일 조회페이지에만 적용했습니다.)

주 원리는 다음과 같습니다.

### 클러스터링 원리

![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/ddf69ace-7d5b-4edf-99e3-532e98fe5468)

위와 같이 현재 지도 사이즈의 실제 우상단 끝점 좌표, 좌하단 끝점 좌표를 얻어냅니다. Map API 중의 getBounds 라는 함수를 쓰면 얻어낼 수 있습니다. 우상단, 좌하단 끝점 좌표를 알면 모든 꼭짓점의 좌표를 알아낼 수 있겠죠?

![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/a800d379-27de-4deb-8490-30c0f5086f7c)

알아낸 좌표를 가지고 지도 스크린 사이즈 만큼의 '실제 거리'를 알 수 있습니다. 이는 LatLng API 중에 distanceTo 라는 함수를 쓰면 두 좌표간의 거리 차이를 구할 수 있는데, 이를 사용해서 구할 수 있습니다.

![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/193ac2eb-0c5b-4145-9c10-42744f77829b)

그런 다음 이제 스크린 사이즈 즉, 지도의 width 값을 알아내야합니다. 이는 Map API 중에 realToScreen 함수를 사용하여 알아낼 수 있습니다. 실제 좌표를 스크린 좌표로 변환해줍니다. 이전에 지도 모서리의 모든 실제 좌표값을 알 수 있었으니, 스크린 사이즈의 좌표값도 쉽게 알아낼 수 있겠죠? 그 좌표값의 x 축 값 차이가 지도의 width가 됩니다.

![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/aec13e80-7536-43c7-837e-9c319c739f08)

이제 마지막으로 지도 위의 **핀이 차지하는 실제 거리**를 알아야하는데요, 핀이 차지하는 지도상 실제 거리는 지도의 줌 상태에 따라서 달라집니다. 줌을 최대로 확대하면 핀이 차지하는 실제 거리는 몇 m에 불과할 것이고, 최대로 축소하면 수십 km 가 될 수도 있겠죠. 이 정보를 백엔드에 넘겨주면 클러스터링을 진행하여 결과값을 반환해주고 이를 받아서 지도에 그리는 것입니다.

위에서 설명드린 로직이 바로 아래의 로직입니다.

```js
// SelectedTopic Page 에서

const getDistanceOfPin = () => {
    if (!mapInstance) return;

    const mapBounds = mapInstance.getBounds();

    const leftWidth = new Tmapv3.LatLng(mapBounds._ne._lat, mapBounds._sw._lng);
    const rightWidth = new Tmapv3.LatLng(
      mapBounds._ne._lat,
      mapBounds._ne._lng,
    );

    const realDistanceOfScreen = leftWidth.distanceTo(rightWidth);
    const currentScreenSize =
      mapInstance.realToScreen(rightWidth).x -
      mapInstance.realToScreen(leftWidth).x;

    return (realDistanceOfScreen / currentScreenSize) * PIN_SIZE;
  };
```
### 지도 이벤트 관리
기존에는 토픽 카드 클릭 한 후에 Markers를 다시 그릴 일이 없었습니다. 그래서 최초에 한 번 get 한 이후에는 지도를 건드릴 일이 없었죠. 그런데 이제는 줌 레벨에 따라서 클러스터링 결과값이 달라지므로 줌 이벤트에 따라서 get 요청을 지속적으로 날려야합니다.

티맵 API 문서에는 안 나와 있지만.. Tmapv3를 console에 직접 찍어보시면 다음과 같은 다양한 이벤트가 있는 것을 확인해볼 수 있습니다.

<img width="447" alt="image" src="https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/3e1f2d64-6f7f-44ff-958e-893ad5ec378f">

우리는 여기서 **ZoomEnd와 DragEnd** 이벤트만 사용할 것입니다. 이벤트명 말 그대로 줌이 끝났을 때, 드래그가 끝났을 때 이벤트가 발생합니다. Zoom과 Drag 이벤트를 사용하게 되면 줌을 하는 동안, 드래그를 하는 동안에도 이벤트가 발생하므로 너무 많은 이벤트가 발생합니다. 디바운스를 걸어주었다고 한들 ZoomEnd와 같은, 특정 행동이 끝났을 때! 이벤트를 발생시킬 수 있는데 이 이벤트를 안 쓸 이유는 없겠죠. (End 이벤트를 썼다고 한들 디바운스는 여전히 걸어줍니다. 간헐적으로 End 이벤트가 짧은 시간에 여러번 발생하기도 해서 그렇습니다.)

아무튼 위 두 개의 이벤트를 지도가 Listen할 수 있도록 합니다. ZoomEnd 시에는 서버에서 새로운 클러스터링 핀 결과값을 받아와 지도를 다시 렌더링합니다. DragEnd 시에는 기존의 pin 배열을 새로운 배열에 전개연산하여 지도를 다시 렌더링합니다. (이 부분은 아래 화면 사이즈에서 보이는 핀만 렌더링하기 파트에서 설명하겠습니다.)

이를 코드로 표현한 것이 다음과 같습니다.

```js
// SelectedTopic Page 에서

useEffect(() => {
    setClusteredCoordinates();

    const onDragEnd = (evt: evt) => {
      if (dragTimerIdRef.current) {
        clearTimeout(dragTimerIdRef.current);
      }

      dragTimerIdRef.current = setTimeout(() => {
        setPrevCoordinates();
      }, 100);
    };
    const onZoomEnd = (evt: evt) => {
      if (zoomTimerIdRef.current) {
        clearTimeout(zoomTimerIdRef.current);
      }

      zoomTimerIdRef.current = setTimeout(() => {
        setClusteredCoordinates();
      }, 100);
    };

    if (!mapInstance) return;

    mapInstance.on('DragEnd', onDragEnd);
    mapInstance.on('ZoomEnd', onZoomEnd);

    return () => {
      mapInstance.off('DragEnd', onDragEnd);
      mapInstance.off('ZoomEnd', onZoomEnd);
    };
  }, [topicDetail]);
```
참고로 on으로 이벤트 핸들러를 달아주고(add) off로 제거할(remove) 수 있습니다. 이거 찾는데 하루 걸렸던건 안 비밀.. (직접 티맵 소스코드 파서 알아냈습니다 ㅋㅋ)

### 화면 사이즈에서 보이는 핀만 렌더링하기
클러스터링을 적용했다고 한들 지도 최적화가 끝난 것은 아닙니다. **클러스터링의 목적은 중첩된 핀들이 너무 많아 지도를 볼 수 없던 문제를 해결하는 것이었죠.** 줌 레벨이 확대되면 클러스터링이 해제되며 모든 핀들이 보이는 상태일 것입니다. 예를 들어, 붕어빵 지도는 지도 최대 축소 상태일땐 핀이 클러스터링 되어 20여개 찍혀있지만, 최대 확대 상태일 땐 800여개의 핀이 그대로 찍혀있습니다.

그 상태에서 지도를 움직이면 (드래그하면) 버벅이는 것은 똑같습니다. 화면 상에는 안 보이지만 800개의 핀이 계속해서 그려지고 있기 때문이죠. 그래서! 화면에 보이는 핀들만 렌더링 하도록합니다.

위에서 지도 모서리 꼭짓점 좌표를 다 얻어올 수 있었습니다. 그 말은 즉, 현재 유저의 화면 좌표 값도 알 수 있겠죠. 현재 화면 좌표값 내부에 포함되어 있는 핀들만 렌더링하도록 하여 버벅임 문제를 해결할 수 있었습니다.

줌을 할 때나 드래그를 할 때나 이 작업은 모두 진행되어야하므로 마커를 그리기 직전에 수행합니다. 로직으로 보면 아래와 같습니다.

```js
// MarkerContext 중

  const createElementsInScreenSize = () => {
    if (!mapInstance) return;

    const mapBounds = mapInstance.getBounds();
    const northEast = mapBounds._ne;
    const southWest = mapBounds._sw;

    const coordinatesInScreenSize = coordinates.filter(
      (coordinate: any) =>
        coordinate.latitude <= northEast._lat &&
        coordinate.latitude >= southWest._lat &&
        coordinate.longitude <= northEast._lng &&
        coordinate.longitude >= southWest._lng,
    );

    return coordinatesInScreenSize;
  };
```
### 사이드바의 PinPreview를 클릭하면..
이 부분이 가장 애를 먹었던 부분입니다. 결과적으로 해결하였지만 아직 안정화가 덜 되어서 추가적으로 리팩토링이 필요해요.

위에서 지도에 달아준 이벤트는 ZoomEnd와 DragEnd 입니다. 하지만 사이드바의 핀프리뷰를 클릭하여 해당 핀으로 포커스 되는 이벤트는 해당되지 않습니다. 기존의 줌, 드래그 이벤트를 감지하면서, 사이드바의 핀프리뷰 포커스 이동까지 감지하는 이벤트는 MoveEnd 와 Idle 이란 이벤트 타입입니다만, 이전 이벤트가 중첩되는 문제가 있었습니다. 즉, 똑같은 마커가 두 번 세 번 그려져서 지워지지가 않는 이슈가 있었습니다. 또한 ZoomEnd 때만 서버에 요청을 보내야하는데 MoveEnd와 Idle 이벤트를 사용하면 드래그 상황에서도 서버에 불필요한 요청을 날리게 됩니다.

그래서 현재는 useAnimateClickedPin 이란 훅에서 클릭된 핀이 있을 경우 이전의 마커를 직접 지우고 지도 줌인 및 가운데로 초점 맞춘 뒤에 마커를 다시 그리는 작업을 수행하고 있습니다. 이 부분이 불안정한데, 가장 큰 문제는 공유하기를 통해 받은 URL 접속 시 해당 핀으로 포커스 작업이 진행되지 않습니다.

또한 useUpdateCoordinates 훅에서 좌표 상태값이 변경되면 알아서 기존 마커를 지우고 재생성하는데 이 부분과 분명 맞물리는 부분이 있을것으로 추정이되는데 실행 흐름순이 맞아서 그런지 문제가 없어보입니다. 최소한 마커 지우고 그리기를 두 번 이상 진행하는 비효율적인 과정인 있어보입니다.

아무튼 위 문제는 모아보기 작업과 동시에 안정화 작업을 진행할 예정입니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
#613 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
