### PR TITLE
[BE] Hotfix/#619 핀 삭제 시 토픽의 핀 개수가 업데이트되지 않는 버그 해결

### DIFF
--- a/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
+++ b/backend/src/main/java/com/mapbefine/mapbefine/admin/application/AdminCommandService.java
@@ -117,6 +117,7 @@ public class AdminCommandService {
                 .orElseThrow(() -> new PinNotFoundException(PIN_NOT_FOUND, pinId));
 
         pin.decreaseTopicPinCount();
+        pinRepository.flush();
         pinImageRepository.deleteAllByPinId(pinId);
         pinRepository.deleteById(pin.getId());
     }

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/AdminIntegrationTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/AdminIntegrationTest.java
@@ -1,6 +1,6 @@
 package com.mapbefine.mapbefine.admin;
 
-import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
@@ -23,7 +23,8 @@ import com.mapbefine.mapbefine.pin.domain.PinRepository;
 import com.mapbefine.mapbefine.topic.TopicFixture;
 import com.mapbefine.mapbefine.topic.domain.Topic;
 import com.mapbefine.mapbefine.topic.domain.TopicRepository;
-import io.restassured.common.mapper.TypeRef;
+import io.restassured.common.mapper.*;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,8 +32,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.List;
 
 class AdminIntegrationTest extends IntegrationTest {
 
@@ -124,15 +123,13 @@ class AdminIntegrationTest extends IntegrationTest {
                 .extract()
                 .as(new TypeRef<>() {
                 });
-        System.out.println("====" + topic.getPinCount());
-        //then
 
+        //then
         AdminMemberDetailResponse expected = AdminMemberDetailResponse.of(
                 member,
                 member.getCreatedTopics(),
                 member.getCreatedPins()
         );
-
         assertThat(response).usingRecursiveComparison()
                 .ignoringFields("updatedAt")
                 .ignoringFields("topics.updatedAt")
@@ -218,6 +215,9 @@ class AdminIntegrationTest extends IntegrationTest {
                 .when().delete("/admin/pins/" + pin.getId())
                 .then().log().all()
                 .statusCode(HttpStatus.NO_CONTENT.value());
+
+        Topic updatedTopic = topicRepository.findById(topic.getId()).get();
+        assertThat(updatedTopic.getPinCount()).isEqualTo(0);
     }
 
     @Test

--- a/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
+++ b/backend/src/test/java/com/mapbefine/mapbefine/admin/application/AdminCommandServiceTest.java
@@ -160,6 +160,20 @@ class AdminCommandServiceTest extends TestDatabaseContainer {
         assertThat(pinRepository.existsById(pin.getId())).isFalse();
     }
 
+    @DisplayName("핀 삭제 시, 토픽의 핀 개수를 1 감소시킨다.")
+    @Test
+    void deletePin_Success_decreaseTopicPinCount() {
+        //given
+        assertThat(pin.isDeleted()).isFalse();
+        int pinCountBeforeDelete = topic.getPinCount();
+
+        //when
+        adminCommandService.deletePin(pin.getId());
+
+        //then
+        assertThat(topic.getPinCount()).isEqualTo(pinCountBeforeDelete - 1);
+    }
+
     @DisplayName("Admin인 경우, 핀 이미지를 삭제할 수 있다.")
     @Test
     void deletePinImage_Success() {


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
- AdminCommandService
- 관련 테스트 코드

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
#619 참조 부탁드립니다. 

간단히 말하면 `pin.decreaseTopicPinCount()`에 대한 변경 감지가 발생하지 않는 문제입니다.
```java
    public void deletePin(Long pinId) {
        Pin pin = pinRepository.findById(pinId)
                .orElseThrow(() -> new PinNotFoundException(PIN_NOT_FOUND, pinId));

        pin.decreaseTopicPinCount();
        pinRepository.flush(); // 추가 된 코드
        pinImageRepository.deleteAllByPinId(pinId);
        pinRepository.deleteById(pin.getId());
    }
```
위 코드에서, deleteXXX 메서드들에 의해 `clearAutomatically = true`로 설정된 네이티브 쿼리가 발생합니다.
이 때 영속성 컨텍스트가 데이터베이스의 내용과 동일하게 초기화됩니다.
따라서 윗줄에서 pin.decreaseTopicPinCount()를 해주었어도,  
커밋하는 시점에서는 영속성 컨텍스트에 해당 변경사항이 반영되지 않는 것입니다.  
그래서 해당 변경을 반영할 수 있도록 flush를 추가했습니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
**실제 운영 환경에 바로 노출되는 부분이므로 main에 대한 hotfix 먼저 올립니다.**
**해당 브랜치 머지 후, dev 브랜치 작업하면 main pull 받은 후 작업부탁드려용**
- 비슷하게, 역정규화된 컬럼의 정보에 대해서 dirty checking이 동작하지 않는 부분이 있는지 테스트를 보완하며 확인해봐도 좋을 것 같아요.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
closed #619

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
