### PR TITLE
[FE] Refactor/#620 모아보기 클러스터링

### DIFF
--- a/frontend/src/components/PinPreview/index.tsx
+++ b/frontend/src/components/PinPreview/index.tsx
@@ -36,7 +36,7 @@ function PinPreview({
   const { pathname } = useLocation();
   const { routePage } = useNavigator();
   const { tags, setTags } = useContext(TagContext);
-  const [announceText, setAnnounceText] = useState<string>('토픽 핀 선택');
+  const [announceText, setAnnounceText] = useState<string>('지도 핀 선택');
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const onAddTagOfTopic = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/components/PullPin/index.tsx
+++ b/frontend/src/components/PullPin/index.tsx
@@ -46,7 +46,7 @@ function PullPin({
               tabIndex={1}
               aria-label={
                 confirmButton === '같이보기'
-                  ? `선택된 ${tag.title} 토픽 태그`
+                  ? `선택된 ${tag.title} 지도 태그`
                   : `선택된 ${tag.title} 핀 태그`
               }
             >
@@ -64,7 +64,7 @@ function PullPin({
           onClick={onClickClose}
           aria-label={
             confirmButton === '같이보기'
-              ? '선택된 토픽들 같이보기 취소하기'
+              ? '선택된 지도들 같이보기 취소하기'
               : '선택된 핀들 뽑아오기 취소하기'
           }
         >
@@ -76,7 +76,7 @@ function PullPin({
           onClick={onClickConfirm}
           aria-label={
             confirmButton === '같이보기'
-              ? '선택된 토픽들 같이보기'
+              ? '선택된 지도들 같이보기'
               : '선택된 핀들 뽑아오기'
           }
         >

--- a/frontend/src/components/TopicCard/index.tsx
+++ b/frontend/src/components/TopicCard/index.tsx
@@ -101,7 +101,7 @@ function TopicCard({
               color="black"
               $fontSize="default"
               $fontWeight="bold"
-              aria-label={`토픽 이름 ${name}`}
+              aria-label={`지도 이름 ${name}`}
             >
               {name}
             </MediaText>

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -60,9 +60,9 @@ function TopicInfo({
     try {
       const topicUrl = window.location.href.split('?')[0];
       await navigator.clipboard.writeText(topicUrl);
-      showToast('info', '토픽 링크가 복사되었습니다.');
+      showToast('info', '지도 링크가 복사되었습니다.');
     } catch (err) {
-      showToast('error', '토픽 링크를 복사하는데 실패했습니다.');
+      showToast('error', '지도 링크를 복사하는데 실패했습니다.');
     }
   };
 

--- a/frontend/src/constants/pinImage.ts
+++ b/frontend/src/constants/pinImage.ts
@@ -9,6 +9,25 @@ export const USER_LOCATION_IMAGE = `<svg width="24" height="24" viewBox="0 0 24 
 `;
 
 export const pinImageMap: PinImageMap = {
+  0: `
+  <svg width="40" height="59" viewBox="0 0 40 59" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M10.8449 50.0736C9.81988 51.3889 7.73559 50.3006 8.22893 48.7078L14.5909 28.1672C14.868 27.2727 15.8879 26.8479 16.718 27.2813L23.5743 30.8611C24.4044 31.2945 24.6388 32.3742 24.0632 33.1129L10.8449 50.0736Z" fill="#454545"/>
+  <circle cx="23.9766" cy="16.8848" r="16" fill="url(#paint0_linear_3559_24273)"/>
+  <circle cx="17.7548" cy="9.77333" r="3.55556" fill="white" fill-opacity="0.6"/>
+  <path d="M28.4206 24.4327C30.5005 25.3845 32.8504 24.7942 34.6186 22.798" stroke="black" stroke-width="1.8" stroke-linecap="round"/>
+  <circle cx="32.4193" cy="13.7738" r="1.33333" fill="black"/>
+  <circle cx="27.0872" cy="18.2181" r="1.33333" fill="black"/>
+  <defs>
+  <linearGradient id="paint0_linear_3559_24273" x1="23.9766" y1="0.884766" x2="23.9766" y2="32.8848" gradientUnits="userSpaceOnUse">
+  <stop stop-color="#E1325C"/>
+  <stop offset="0.25" stop-color="#F9CB55"/>
+  <stop offset="0.5" stop-color="#2AC1BC"/>
+  <stop offset="0.75" stop-color="#4B5CFA"/>
+  <stop offset="1" stop-color="#C340B6"/>
+  </linearGradient>
+  </defs>
+  </svg>
+  `,
   1: `<svg width="60" height="60" viewBox="0 0 40 58" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M10.8449 48.4877C9.81988 49.803 7.73559 48.7147 8.22893 47.1219L14.5909 26.5813C14.868 25.6867 15.8879 25.262 16.718 25.6954L23.5743 29.2752C24.4044 29.7086 24.6388 30.7883 24.0632 31.5269L10.8449 48.4877Z" fill="#454545"/>
 <circle cx="23.9766" cy="16" r="16" fill="#E1325C"/>
@@ -75,6 +94,7 @@ export const pinImageMap: PinImageMap = {
 };
 
 export const pinColors: PinImageMap = {
+  0: '#454545',
   1: '#E1325C',
   2: '#F9CB55',
   3: '#4B5CFA',

--- a/frontend/src/constants/pinImage.ts
+++ b/frontend/src/constants/pinImage.ts
@@ -123,20 +123,22 @@ ${
           (
             pin: any,
           ) => `<div style="border-bottom: 1px solid white; padding: 4px 12px; display:flex; border-radius: 20px; justify-content: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${backgroundColor};">
-  ${pin.name}
-  </div>`,
+                  ${pin.name}
+                </div>`,
         )
         .join('')
     : `<div style="padding: 4px 12px; display:flex; border-radius: 20px; justify-content: center; align-items: center; height:32px; font-size:14px; color:#ffffff; background-color: ${backgroundColor};">
-  ${pinName}
-  </div>
+        ${pinName}
+      </div>
   ${
     pins.length > 1
       ? `
-      <div style="position: absolute; top: -14px; right: -12px; padding: 2px 4px; font-size: 14px; background-color: #fff; border-radius: 50%; border: 1px solid ${backgroundColor}; color: ${backgroundColor}">+${pins.length}</div>
+      <div style="position: absolute; top: -14px; right: -12px; padding: 2px 4px; font-size: 14px; background-color: #fff; border-radius: 50%; border: 1px solid ${backgroundColor}; color: ${backgroundColor}">
+        +${pins.length}
+      </div>
       `
       : ''
   }
-  </div>`
+  `
 }
-`;
+</div>`;

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -96,15 +96,21 @@ function MarkerProvider({ children }: Props): JSX.Element {
     let markerType = -1;
     let currentTopicId = '-1';
 
-    const markersInScreenSize = createElementsInScreenSize();
+    const coordinatesInScreenSize = createElementsInScreenSize();
 
-    if (!markersInScreenSize) return;
+    if (!coordinatesInScreenSize) return;
 
-    const newMarkers = markersInScreenSize.map((coordinate: any) => {
-      if (currentTopicId !== coordinate.topicId) {
+    console.log(coordinatesInScreenSize);
+
+    const newMarkers = coordinatesInScreenSize.map((coordinate: any) => {
+      if (coordinate.topicId === 'clustered') {
+        markerType = -1;
+      } else if (currentTopicId !== coordinate.topicId) {
         markerType = (markerType + 1) % 7;
         currentTopicId = coordinate.topicId;
       }
+      console.log(markerType);
+
       const marker = createMarker(coordinate, markerType);
       marker.id = String(coordinate.id);
       return marker;
@@ -138,12 +144,14 @@ function MarkerProvider({ children }: Props): JSX.Element {
     let markerType = -1;
     let currentTopicId = '-1';
 
-    const windowsInScreenSize = createElementsInScreenSize();
+    const coordinatesInScreenSize = createElementsInScreenSize();
 
-    if (!windowsInScreenSize) return;
+    if (!coordinatesInScreenSize) return;
 
-    const newInfowindows = windowsInScreenSize.map((coordinate: any) => {
-      if (currentTopicId !== coordinate.topicId) {
+    const newInfowindows = coordinatesInScreenSize.map((coordinate: any) => {
+      if (coordinate.topicId === 'clustered') {
+        markerType = -1;
+      } else if (currentTopicId !== coordinate.topicId) {
         markerType = (markerType + 1) % 7;
         currentTopicId = coordinate.topicId;
       }

--- a/frontend/src/context/MarkerContext.tsx
+++ b/frontend/src/context/MarkerContext.tsx
@@ -20,6 +20,8 @@ type MarkerContextType = {
   displayClickedMarker: () => void;
 };
 
+type ElementType = 'marker' | 'infoWindow';
+
 const defaultMarkerContext = () => {
   throw new Error('MarkerContext가 제공되지 않았습니다.');
 };
@@ -48,8 +50,6 @@ function MarkerProvider({ children }: Props): JSX.Element {
   const { topicId } = useParams<{ topicId: string }>();
   const { routePage } = useNavigator();
   const { pathname } = useLocation();
-
-  type ElementType = 'marker' | 'infoWindow';
 
   const createElementsColor = (elementType: ElementType = 'marker') => {
     let markerType = -1;

--- a/frontend/src/hooks/useClickedCoordinate.ts
+++ b/frontend/src/hooks/useClickedCoordinate.ts
@@ -13,7 +13,7 @@ export default function useClickedCoordinate() {
   useEffect(() => {
     if (!mapInstance) return;
     const currentZoom = mapInstance.getZoom();
-    if (clickedCoordinate.address) displayClickedMarker(mapInstance);
+    if (clickedCoordinate.address) displayClickedMarker();
 
     // 선택된 좌표가 있으면 해당 좌표로 지도의 중심을 이동
     if (clickedCoordinate.latitude && clickedCoordinate.longitude) {

--- a/frontend/src/hooks/useRealDistanceOfPin.ts
+++ b/frontend/src/hooks/useRealDistanceOfPin.ts
@@ -1,0 +1,26 @@
+import { PIN_SIZE } from '../constants';
+
+const useRealDistanceOfPin = () => {
+  const { Tmapv3 } = window;
+
+  const getDistanceOfPin = (mapInstance: TMap) => {
+    const mapBounds = mapInstance.getBounds();
+
+    const leftWidth = new Tmapv3.LatLng(mapBounds._ne._lat, mapBounds._sw._lng);
+    const rightWidth = new Tmapv3.LatLng(
+      mapBounds._ne._lat,
+      mapBounds._ne._lng,
+    );
+
+    const realDistanceOfScreen = leftWidth.distanceTo(rightWidth);
+    const currentScreenSize =
+      mapInstance.realToScreen(rightWidth).x -
+      mapInstance.realToScreen(leftWidth).x;
+
+    return (realDistanceOfScreen / currentScreenSize) * PIN_SIZE;
+  };
+
+  return { getDistanceOfPin };
+};
+
+export default useRealDistanceOfPin;

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -356,7 +356,7 @@ function NewPin() {
         <ModalContentsWrapper>
           <Space size={5} />
           <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
-            내 토픽 리스트
+            내 지도 리스트
           </Text>
           <Text color="gray" $fontSize="small" $fontWeight="normal">
             핀을 저장할 지도를 선택해주세요.

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -303,7 +303,7 @@ function PinDetail({
         <ModalContentsWrapper>
           <Space size={5} />
           <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
-            내 토픽 리스트
+            내 지도 리스트
           </Text>
           <Text color="gray" $fontSize="small" $fontWeight="normal">
             핀을 저장할 지도를 선택해주세요.

--- a/frontend/src/pages/SeeTogether.tsx
+++ b/frontend/src/pages/SeeTogether.tsx
@@ -29,7 +29,6 @@ import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
 import useTags from '../hooks/useTags';
 import useMapStore from '../store/mapInstance';
-import { PinProps } from '../types/Pin';
 import { TopicDetailProps } from '../types/Topic';
 import PinDetail from './PinDetail';
 
@@ -38,7 +37,7 @@ function SeeTogether() {
 
   const { topicId } = useParams();
   const { routePage } = useNavigator();
-  const [searchParams, _] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const location = useLocation();
 
   const [isOpen, setIsOpen] = useState(true);
@@ -79,7 +78,6 @@ function SeeTogether() {
     );
 
     setTopicDetails(topics);
-    setClusteredCoordinates();
   };
 
   const setClusteredCoordinates = async () => {
@@ -124,7 +122,22 @@ function SeeTogether() {
     setCoordinates((prev) => [...prev]);
   };
 
+  const togglePinDetail = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const initMarkerWhenSeeTogetherIsEmpty = () => {
+    setCoordinates([]);
+
+    if (markers && markers.length > 0) {
+      removeMarkers();
+      removeInfowindows();
+    }
+  };
+
   useEffect(() => {
+    setClusteredCoordinates();
+
     const onDragEnd = (evt: evt) => {
       if (dragTimerIdRef.current) {
         clearTimeout(dragTimerIdRef.current);
@@ -155,10 +168,6 @@ function SeeTogether() {
     };
   }, [topicDetails]);
 
-  const togglePinDetail = () => {
-    setIsOpen(!isOpen);
-  };
-
   useEffect(() => {
     const queryParams = new URLSearchParams(location.search);
 
@@ -173,15 +182,9 @@ function SeeTogether() {
 
   useEffect(() => {
     getAndSetDataFromServer();
-  }, [topicId]);
-
-  useEffect(() => {
     setTags([]);
 
-    if (markers && markers.length > 0) {
-      removeMarkers();
-      removeInfowindows();
-    }
+    initMarkerWhenSeeTogetherIsEmpty();
   }, []);
 
   if (!seeTogetherTopics || !topicId) return <></>;

--- a/frontend/src/pages/SeeTogether.tsx
+++ b/frontend/src/pages/SeeTogether.tsx
@@ -95,7 +95,10 @@ function SeeTogether() {
     diameterPins.forEach((clusterOrPin: any, idx: number) => {
       newCoordinates.push({
         topicId:
-          clusterOrPin.pins.length > 1
+          clusterOrPin.pins.length > 1 &&
+          clusterOrPin.pins.filter(
+            (pin: any) => pin.topicId !== clusterOrPin.pins[0].topicId,
+          ).length !== 0
             ? 'clustered'
             : clusterOrPin.pins[0].topicId,
         id: clusterOrPin.pins[0].id || `cluster ${idx}`,

--- a/frontend/src/types/tmap.d.ts
+++ b/frontend/src/types/tmap.d.ts
@@ -59,6 +59,7 @@ interface InfoWindow {
   map?: Map;
   setMap(mapOrNull?: Map | null): void;
   setPosition(positionOrLatLng?: Position | LatLng): void;
+  getPosition(): LatLng;
   setContent(contentOrString?: Content | string): void;
   open(map?: Map, marker?: Marker, latlng?: LatLng): void;
   close(): void;


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
* 모아보기 페이지에 클러스터링 및 스크린 사이즈 마커 렌더링을 진행한다.

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] 모아보기 클러스터링 적용
- [x] 모아보기 전용 클러스터링 핀 이미지 만들기
- [x] 토픽 -> 지도로 명칭 일괄 변경 

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
* SeeTogether 페이지에서 모아보기 핀인지 구분하고 정렬하는 과정의 로직이 조금 복잡합니다. 추후 모아보기 된의 색깔을 무지개 색에서 모아보기 된 핀들의 색깔로만 동적으로 만들어낼 계획이기에 이 리팩토링을 진행하면서 수정해보겠습니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->
<img width="1470" alt="image" src="https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/54d30a70-e1bb-46ec-8a46-d1136b8e1374">

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
close #620
## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
