### PR TITLE
[FE] Refactor 지도 회전 및 기울기 이벤트 시 지도를 원래대로 조정

### DIFF
--- a/frontend/src/pages/SeeTogether.tsx
+++ b/frontend/src/pages/SeeTogether.tsx
@@ -135,6 +135,13 @@ function SeeTogether() {
     }
   };
 
+  const adjustMapDirection = () => {
+    if (!mapInstance) return;
+
+    mapInstance.setBearing(0);
+    mapInstance.setPitch(0);
+  };
+
   useEffect(() => {
     setClusteredCoordinates();
 
@@ -145,6 +152,7 @@ function SeeTogether() {
 
       dragTimerIdRef.current = setTimeout(() => {
         setPrevCoordinates();
+        adjustMapDirection();
       }, 100);
     };
     const onZoomEnd = (evt: evt) => {
@@ -154,6 +162,7 @@ function SeeTogether() {
 
       zoomTimerIdRef.current = setTimeout(() => {
         setClusteredCoordinates();
+        adjustMapDirection();
       }, 100);
     };
 

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -76,6 +76,13 @@ function SelectedTopic() {
     setCoordinates((prev) => [...prev]);
   };
 
+  const adjustMapDirection = () => {
+    if (!mapInstance) return;
+
+    mapInstance.setBearing(0);
+    mapInstance.setPitch(0);
+  };
+
   useEffect(() => {
     getAndSetDataFromServer();
     setTags([]);
@@ -91,6 +98,7 @@ function SelectedTopic() {
 
       dragTimerIdRef.current = setTimeout(() => {
         setPrevCoordinates();
+        adjustMapDirection();
       }, 100);
     };
     const onZoomEnd = (evt: evt) => {
@@ -100,6 +108,7 @@ function SelectedTopic() {
 
       zoomTimerIdRef.current = setTimeout(() => {
         setClusteredCoordinates();
+        adjustMapDirection();
       }, 100);
     };
 

--- a/frontend/src/types/tmap.d.ts
+++ b/frontend/src/types/tmap.d.ts
@@ -34,6 +34,8 @@ interface TMap {
   getBounds(): LatLngBounds;
   realToScreen(latLng: LatLng): Point;
   off(eventType: string, callback: (event: evt) => void): void;
+  setBearing(value: number): void;
+  setPitch(value: number): void;
 }
 
 interface Marker {


### PR DESCRIPTION

<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
지도 회전 및 기울기 이벤트를 허용하나, 이후 지도를 움직이거나 줌인, 줌아웃하면 원래의 방향 bearing: 0, pitch: 0으로 돌려놓는다.
이는 모바일에서 줌인 줌아웃시 지도가 돌아가서 원래대로 돌려놓는데 불편함이 있었으며 클러스터링 안정화를 위해 위와 같이 작업한다.

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
