### PR TITLE
[FE] Refactor/#628 시맨틱 태그, 웹 표준, 웹 접근성 검토

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     'react/jsx-props-no-spreading': 'off',
     'react/no-unused-prop-types': 'off',
     'no-underscore-dangle': 'off',
+    'default-case': 'off',
   },
   settings: {
     'import/resolver': {

--- a/frontend/cypress/e2e/mapbefine.cy.ts
+++ b/frontend/cypress/e2e/mapbefine.cy.ts
@@ -4,9 +4,7 @@ describe('메인 페이지', () => {
   });
 
   it('로고와 다양한 지도 소개 글이 보인다.', () => {
-    cy.get('div[aria-label="괜찮을지도 로고 및 홈으로 이동 버튼"]').should(
-      'be.visible',
-    );
+    cy.get('[data-cy="logo"]').should('be.visible');
 
     cy.contains('인기 급상승할 지도').should('be.visible');
   });

--- a/frontend/src/GlobalStyle.ts
+++ b/frontend/src/GlobalStyle.ts
@@ -4,6 +4,7 @@ const GlobalStyle = createGlobalStyle`
   html,
   body,
   h2,
+  h3,
   textarea{
     padding:0;
     margin:0;

--- a/frontend/src/GlobalStyle.ts
+++ b/frontend/src/GlobalStyle.ts
@@ -3,6 +3,7 @@ import { createGlobalStyle } from 'styled-components';
 const GlobalStyle = createGlobalStyle`
   html,
   body,
+  h2,
   textarea{
     padding:0;
     margin:0;

--- a/frontend/src/components/AddFavorite/index.tsx
+++ b/frontend/src/components/AddFavorite/index.tsx
@@ -2,6 +2,7 @@ import { styled } from 'styled-components';
 
 import { deleteApi } from '../../apis/deleteApi';
 import { postApi } from '../../apis/postApi';
+import { ARIA_FOCUS } from '../../constants';
 import useToast from '../../hooks/useToast';
 
 interface AddFavoriteProps {
@@ -48,7 +49,12 @@ function AddFavorite({
   };
 
   return (
-    <Wrapper onClick={isBookmarked ? deleteFavoriteList : addFavoriteList}>
+    <Wrapper
+      tabIndex={ARIA_FOCUS}
+      role="button"
+      aria-label="즐겨찾기 추가 버튼"
+      onClick={isBookmarked ? deleteFavoriteList : addFavoriteList}
+    >
       {children}
     </Wrapper>
   );

--- a/frontend/src/components/AddSeeTogether/index.tsx
+++ b/frontend/src/components/AddSeeTogether/index.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 import { deleteApi } from '../../apis/deleteApi';
 import { getApi } from '../../apis/getApi';
 import { postApi } from '../../apis/postApi';
+import { ARIA_FOCUS } from '../../constants';
 import { SeeTogetherContext } from '../../context/SeeTogetherContext';
 import useNavigator from '../../hooks/useNavigator';
 import useToast from '../../hooks/useToast';
@@ -108,7 +109,12 @@ function AddSeeTogether({
   }
 
   return (
-    <Wrapper onClick={isInAtlas ? deleteSeeTogether : addSeeTogetherList}>
+    <Wrapper
+      tabIndex={ARIA_FOCUS}
+      role="button"
+      aria-label="모아보기 추가 버튼"
+      onClick={isInAtlas ? deleteSeeTogether : addSeeTogetherList}
+    >
       {children}
     </Wrapper>
   );

--- a/frontend/src/components/AuthorityRadioContainer/index.tsx
+++ b/frontend/src/components/AuthorityRadioContainer/index.tsx
@@ -3,6 +3,7 @@ import { useContext, useState } from 'react';
 import styled from 'styled-components';
 
 import useGet from '../../apiHooks/useGet';
+import { ARIA_FOCUS } from '../../constants';
 import { ModalContext } from '../../context/ModalContext';
 import {
   TopicAuthorMember,
@@ -80,7 +81,7 @@ function AuthorityRadioContainer({
             id="publicity-public"
             checked={!isPrivate}
             onChange={() => setIsPrivate(false)}
-            tabIndex={4}
+            tabIndex={ARIA_FOCUS}
           />
           <Space size={1} />
           <label htmlFor="publicity-public">공개 지도</label>
@@ -93,7 +94,7 @@ function AuthorityRadioContainer({
           id="publicity-private"
           checked={isPrivate}
           onChange={() => setIsPrivate(true)}
-          tabIndex={4}
+          tabIndex={ARIA_FOCUS}
         />
         <Space size={1} />
         <label htmlFor="publicity-private">비공개 지도</label>
@@ -115,7 +116,7 @@ function AuthorityRadioContainer({
             id="permission-all"
             checked={isAllPermissioned}
             onChange={onChangeInitAuthMembersWithSetIsAllPermissioned}
-            tabIndex={5}
+            tabIndex={ARIA_FOCUS}
           />
           <Space size={1} />
           {isPrivate ? (
@@ -135,7 +136,7 @@ function AuthorityRadioContainer({
           onClick={() => {
             isAllPermissioned === false && openModal('newTopic');
           }}
-          tabIndex={5}
+          tabIndex={ARIA_FOCUS}
         />
         <Space size={1} />
         <label htmlFor="permission-group">친구들에게</label>
@@ -237,7 +238,7 @@ function AuthorityRadioContainer({
 
           <Flex $justifyContent="end" padding="12px" bottom="0px">
             <Button
-              tabIndex={6}
+              tabIndex={ARIA_FOCUS}
               type="button"
               variant="secondary"
               onClick={() => {
@@ -252,7 +253,7 @@ function AuthorityRadioContainer({
             <Space size={3} />
 
             <Button
-              tabIndex={6}
+              tabIndex={ARIA_FOCUS}
               variant="primary"
               onClick={() => {
                 closeModal('newTopic');

--- a/frontend/src/components/Banner/index.tsx
+++ b/frontend/src/components/Banner/index.tsx
@@ -39,13 +39,18 @@ export default function Banner() {
             width="100%"
             src={BannerItemBoongWEBP}
             alt="붕어빵 배너"
+            aria-label="대동붕어빵여지도로 이동"
           />
         </Box>
       </Tab>
       <Tab label="사용법">
         <Box cursor="pointer">
           <a href={USAGE_URL} target="blank">
-            <BannerImage src={BannerItemUsageWEBP} alt="사용법 배너" />
+            <BannerImage
+              src={BannerItemUsageWEBP}
+              alt="사용법 배너"
+              aria-label="새 창을 띄워 사용법 페이지로 이동"
+            />
           </a>
         </Box>
       </Tab>

--- a/frontend/src/components/Banner/index.tsx
+++ b/frontend/src/components/Banner/index.tsx
@@ -23,6 +23,7 @@ export default function Banner() {
 
   return (
     <Swiper
+      as="section"
       width={1140}
       height={400}
       $simpleTab

--- a/frontend/src/components/InputContainer/index.tsx
+++ b/frontend/src/components/InputContainer/index.tsx
@@ -52,7 +52,7 @@ function InputContainer({
   };
 
   return (
-    <>
+    <section>
       <Flex>
         <Text color="black" $fontSize="default" $fontWeight="normal">
           {containerTitle}
@@ -106,7 +106,7 @@ function InputContainer({
       )}
       <Space size={0} />
       <ErrorText>{errorMessage}</ErrorText>
-    </>
+    </section>
   );
 }
 const ErrorText = styled.span`

--- a/frontend/src/components/Layout/Logo.tsx
+++ b/frontend/src/components/Layout/Logo.tsx
@@ -17,8 +17,8 @@ function Logo() {
       onKeyDown={onElementKeyDown}
       ref={elementRef}
       onClick={goToHome}
-      aria-label="괜찮을지도 로고 및 홈으로 이동 버튼"
       tabIndex={0}
+      aria-label="괜찮을지도 로고 및 홈으로 이동하기"
     >
       <LogoImage />
     </Box>

--- a/frontend/src/components/Layout/Logo.tsx
+++ b/frontend/src/components/Layout/Logo.tsx
@@ -19,6 +19,7 @@ function Logo() {
       onClick={goToHome}
       tabIndex={0}
       aria-label="괜찮을지도 로고 및 홈으로 이동하기"
+      data-cy="logo"
     >
       <LogoImage />
     </Box>

--- a/frontend/src/components/Layout/index.tsx
+++ b/frontend/src/components/Layout/index.tsx
@@ -67,6 +67,7 @@ function Layout({ children }: LayoutProps) {
                         </Box>
                       </LogoWrapper>
                       <Flex
+                        as="main"
                         $flexDirection="column"
                         height="inherit"
                         overflow="auto"
@@ -88,7 +89,7 @@ function Layout({ children }: LayoutProps) {
   );
 }
 
-const LogoWrapper = styled.section<{
+const LogoWrapper = styled.header<{
   $layoutWidth: '372px' | '100vw';
 }>`
   width: 372px;
@@ -107,7 +108,7 @@ const LogoWrapper = styled.section<{
   }
 `;
 
-const MediaWrapper = styled.section<{
+const MediaWrapper = styled.div<{
   $isAddPage: boolean;
   $layoutWidth: '372px' | '100vw';
 }>`

--- a/frontend/src/components/Map/index.tsx
+++ b/frontend/src/components/Map/index.tsx
@@ -81,7 +81,7 @@ function Map() {
   );
 }
 
-const MapContainer = styled.div`
+const MapContainer = styled.section`
   width: 100%;
   height: 100%;
   position: relative;

--- a/frontend/src/components/MyInfo/index.tsx
+++ b/frontend/src/components/MyInfo/index.tsx
@@ -104,13 +104,6 @@ const MyInfoContainer = styled(Flex)`
   border: 1px solid ${({ theme }) => theme.color.lightGray};
 `;
 
-const MyInfoImg = styled.img`
-  width: 80px;
-  height: 80px;
-
-  border-radius: 50%;
-`;
-
 const SettingContainer = styled.div`
   position: absolute;
   top: 10px;

--- a/frontend/src/components/MyInfo/index.tsx
+++ b/frontend/src/components/MyInfo/index.tsx
@@ -74,9 +74,14 @@ function MyInfo() {
       $justifyContent="center"
       $alignItems="center"
       tabIndex={ARIA_FOCUS}
-      aria-label={`내 정보 영역입니다. 나의 이름은 ${user.nickName}이고 이메일은 ${user.email} 입니다.`}
+      aria-label={`내 정보 영역입니다. 나의 닉네임은 ${user.nickName}이고 이메일은 ${user.email} 입니다.`}
     >
-      <SettingContainer onClick={onClickSetting}>
+      <SettingContainer
+        onClick={onClickSetting}
+        tabIndex={ARIA_FOCUS}
+        role="button"
+        aria-label="내 닉네임 수정하기"
+      >
         <Setting />
       </SettingContainer>
       <Image

--- a/frontend/src/components/MyInfo/index.tsx
+++ b/frontend/src/components/MyInfo/index.tsx
@@ -2,7 +2,11 @@ import { SyntheticEvent, useState } from 'react';
 import { styled } from 'styled-components';
 
 import Setting from '../../assets/updateBtn.svg';
-import { DEFAULT_PROD_URL, DEFAULT_PROFILE_IMAGE } from '../../constants';
+import {
+  ARIA_FOCUS,
+  DEFAULT_PROD_URL,
+  DEFAULT_PROFILE_IMAGE,
+} from '../../constants';
 import useToast from '../../hooks/useToast';
 import { ProfileProps } from '../../types/Profile';
 import Box from '../common/Box';
@@ -69,6 +73,8 @@ function MyInfo() {
       $borderRadius="medium"
       $justifyContent="center"
       $alignItems="center"
+      tabIndex={ARIA_FOCUS}
+      aria-label={`내 정보 영역입니다. 나의 이름은 ${user.nickName}이고 이메일은 ${user.email} 입니다.`}
     >
       <SettingContainer onClick={onClickSetting}>
         <Setting />

--- a/frontend/src/components/PinPreview/index.tsx
+++ b/frontend/src/components/PinPreview/index.tsx
@@ -167,6 +167,23 @@ const MultiSelectButton = styled.input`
   width: 24px;
   height: 24px;
   cursor: pointer;
+
+  -webkit-appearance: none;
+  appearance: none;
+  border-radius: 0.15em;
+  margin-right: 0.5em;
+  border: 0.1em solid ${({ theme }) => theme.color.black};
+  background-color: ${({ theme }) => theme.color.white};
+  outline: none;
+
+  &:checked {
+    border-color: transparent;
+    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
+    background-size: 100% 100%;
+    background-position: 50%;
+    background-repeat: no-repeat;
+    background-color: ${({ theme }) => theme.color.checked};
+  }
 `;
 
 const EllipsisTitle = styled(Text)`

--- a/frontend/src/components/PinPreview/index.tsx
+++ b/frontend/src/components/PinPreview/index.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import { TagContext } from '../../context/TagContext';
+import useAriaLive from '../../hooks/useAriaLive';
 import useNavigator from '../../hooks/useNavigator';
 import theme from '../../themes';
 import Box from '../common/Box';
@@ -36,8 +37,32 @@ function PinPreview({
   const { pathname } = useLocation();
   const { routePage } = useNavigator();
   const { tags, setTags } = useContext(TagContext);
-  const [announceText, setAnnounceText] = useState<string>('지도 핀 선택');
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const { setAriaLiveTagInnerText } = useAriaLive({
+    liveTagId: 'live-region',
+    defaultAnnounceText: '지도 핀 선택',
+  });
+
+  const addTagsAnnounceText = () => {
+    if (tags.length === 0) {
+      setAriaLiveTagInnerText(
+        `핀 ${pinTitle}이 뽑아오기 목록에 추가됨. 뽑아오기 기능을 활성화 합니다.`,
+      );
+      return;
+    }
+
+    setAriaLiveTagInnerText(`핀 ${pinTitle}이 뽑아오기 목록에 추가됨`);
+  };
+
+  const deleteTagsAnnounceText = () => {
+    if (tags.length === 1) {
+      setAriaLiveTagInnerText(
+        `핀 ${pinTitle}이 뽑아오기 목록에서 삭제됨. 뽑아오기 기능을 비활성화 합니다.`,
+      );
+      return;
+    }
+    setAriaLiveTagInnerText(`핀 ${pinTitle}이 뽑아오기 목록에서 삭제됨`);
+  };
 
   const onAddTagOfTopic = (e: React.ChangeEvent<HTMLInputElement>) => {
     e.stopPropagation();
@@ -45,21 +70,11 @@ function PinPreview({
     if (e.target.checked) {
       setTags((prevTags) => [...prevTags, { id: pinId, title: pinTitle }]);
 
-      if (tags.length === 0) {
-        setAnnounceText(`핀 ${pinTitle}이 태그에 추가됨. 뽑아오기 기능 활성화`);
-        return;
-      }
-      setAnnounceText(`핀 ${pinTitle}이 태그에 추가됨`);
+      addTagsAnnounceText();
     } else {
       setTags(tags.filter((tag) => tag.id !== pinId));
 
-      if (tags.length === 1) {
-        setAnnounceText(
-          `핀 ${pinTitle}이 태그에서 삭제됨. 뽑아오기 기능 비활성화`,
-        );
-        return;
-      }
-      setAnnounceText(`핀 ${pinTitle}이 태그에서 삭제됨`);
+      deleteTagsAnnounceText();
     }
   };
 
@@ -82,15 +97,6 @@ function PinPreview({
     }
   };
 
-  useEffect(() => {
-    if (announceText) {
-      const liveRegion = document.getElementById('live-region');
-      if (liveRegion) {
-        liveRegion.innerText = announceText;
-      }
-    }
-  }, [announceText]);
-
   return (
     <Flex
       height="152px"
@@ -110,11 +116,21 @@ function PinPreview({
         role="button"
       >
         <Space size={1} />
-        <EllipsisTitle color="black" $fontSize="default" $fontWeight="bold">
+        <EllipsisTitle
+          color="black"
+          $fontSize="default"
+          $fontWeight="bold"
+          aria-label={`장소 이름은 ${pinTitle} 이고`}
+        >
           {pinTitle}
         </EllipsisTitle>
         <Space size={0} />
-        <Text color="gray" $fontSize="small" $fontWeight="normal">
+        <Text
+          color="gray"
+          $fontSize="small"
+          $fontWeight="normal"
+          aria-label={`장소의 위치는 ${pinLocation} 입니다.`}
+        >
           {pinLocation}
         </Text>
         <Space size={3} />
@@ -122,6 +138,7 @@ function PinPreview({
           color="black"
           $fontSize="small"
           $fontWeight="normal"
+          aria-label={`이 장소에 대한 미리보기 설명은 다음과 같습니다. ${pinInformation}`}
         >
           {pinInformation}
         </EllipsisDescription>
@@ -133,7 +150,7 @@ function PinPreview({
           onChange={onAddTagOfTopic}
           onKeyDown={onInputKeyDown}
           checked={Boolean(tags.map((tag) => tag.id).includes(pinId))}
-          aria-label={`${pinTitle} 핀 선택`}
+          aria-label={`${pinTitle} 장소 뽑아오기 선택`}
           ref={inputRef}
         />
       </Box>

--- a/frontend/src/components/TopicCard/index.tsx
+++ b/frontend/src/components/TopicCard/index.tsx
@@ -79,6 +79,7 @@ function TopicCard({
       onKeyDown={onElementKeyDown}
     >
       <Flex
+        as="article"
         $flexDirection="column"
         position="relative"
         tabIndex={0}
@@ -174,7 +175,7 @@ function TopicCard({
   );
 }
 
-const Wrapper = styled.article`
+const Wrapper = styled.li`
   cursor: pointer;
   border-radius: ${({ theme }) => theme.radius.small};
 `;

--- a/frontend/src/components/TopicCard/index.tsx
+++ b/frontend/src/components/TopicCard/index.tsx
@@ -94,6 +94,7 @@ function TopicCard({
           $errorDefaultSrc={DEFAULT_TOPIC_IMAGE}
           radius="small"
           ratio="1.6 / 1"
+          isAriaHidden
         />
 
         <Box width="100%" $maxWidth="212px" padding={1}>
@@ -102,7 +103,7 @@ function TopicCard({
               color="black"
               $fontSize="default"
               $fontWeight="bold"
-              aria-label={`지도 이름 ${name}`}
+              aria-label={`지도 이름은 ${name} 입니다.`}
             >
               {name}
             </MediaText>
@@ -112,14 +113,21 @@ function TopicCard({
             color="black"
             $fontSize="small"
             $fontWeight="normal"
-            aria-label={`작성자 ${creator}`}
+            aria-label={`작성자는 ${creator} 이며`}
           >
             {creator}
           </MediaText>
 
           <Space size={0} />
 
-          <MediaText color="gray" $fontSize="small" $fontWeight="normal">
+          <MediaText
+            color="gray"
+            $fontSize="small"
+            $fontWeight="normal"
+            aria-label={`${updatedAt
+              .split('T')[0]
+              .replaceAll('-', '.')}에 마지막으로 업데이트 되었습니다.`}
+          >
             {updatedAt.split('T')[0].replaceAll('-', '.')} 업데이트
           </MediaText>
 
@@ -133,7 +141,7 @@ function TopicCard({
                 color="black"
                 $fontSize="extraSmall"
                 $fontWeight="normal"
-                aria-label={`핀 갯수 ${pinCount}개`}
+                aria-label={`핀 갯수는 ${pinCount}개 이며`}
               >
                 {pinCount > 999 ? '+999' : pinCount}개
               </MediaText>
@@ -145,7 +153,7 @@ function TopicCard({
                 color="black"
                 $fontSize="extraSmall"
                 $fontWeight="normal"
-                aria-label={`즐겨찾기 ${bookmarkCount}명`}
+                aria-label={`즐겨찾기는 ${bookmarkCount}명 입니다.`}
               >
                 {bookmarkCount > 999 ? '+999' : bookmarkCount}명
               </MediaText>

--- a/frontend/src/components/TopicCard/index.tsx
+++ b/frontend/src/components/TopicCard/index.tsx
@@ -174,7 +174,7 @@ function TopicCard({
   );
 }
 
-const Wrapper = styled.li`
+const Wrapper = styled.article`
   cursor: pointer;
   border-radius: ${({ theme }) => theme.radius.small};
 `;

--- a/frontend/src/components/TopicCardContainer/index.tsx
+++ b/frontend/src/components/TopicCardContainer/index.tsx
@@ -98,7 +98,7 @@ function TopicCardContainer({
             (topic, index) =>
               index < 10 && (
                 <Tab label={`${index}`} key={topic.id}>
-                  <Flex as="li">
+                  <Flex>
                     <CustomSpace />
                     <TopicCard
                       cardType="default"

--- a/frontend/src/components/TopicCardContainer/index.tsx
+++ b/frontend/src/components/TopicCardContainer/index.tsx
@@ -73,7 +73,8 @@ function TopicCardContainer({
           $fontWeight="normal"
           tabIndex={0}
           onClick={routeWhenSeeAll}
-          aria-label={`${containerTitle} 전체보기 버튼`}
+          role="button"
+          aria-label={`${containerTitle} 전체보기`}
           ref={elementRef}
           onKeyDown={onElementKeyDown}
         >

--- a/frontend/src/components/TopicCardContainer/index.tsx
+++ b/frontend/src/components/TopicCardContainer/index.tsx
@@ -48,6 +48,7 @@ function TopicCardContainer({
       <Flex $justifyContent="space-between" $alignItems="flex-end">
         <Box>
           <MediaText
+            as="h2"
             color="black"
             $fontSize="extraLarge"
             $fontWeight="bold"
@@ -97,7 +98,7 @@ function TopicCardContainer({
             (topic, index) =>
               index < 10 && (
                 <Tab label={`${index}`} key={topic.id}>
-                  <Flex>
+                  <Flex as="li">
                     <CustomSpace />
                     <TopicCard
                       cardType="default"

--- a/frontend/src/components/TopicCardList/index.tsx
+++ b/frontend/src/components/TopicCardList/index.tsx
@@ -104,7 +104,7 @@ const EmptyWrapper = styled.section`
   align-items: center;
 `;
 
-const Wrapper = styled.ul`
+const Wrapper = styled.section`
   display: flex;
   flex-wrap: wrap;
   gap: 20px;

--- a/frontend/src/components/TopicCardList/index.tsx
+++ b/frontend/src/components/TopicCardList/index.tsx
@@ -76,7 +76,7 @@ function TopicCardList({
         ]}
       >
         {topics.map((topic) => (
-          <Fragment key={topic.id}>
+          <ul key={topic.id}>
             <TopicCard
               cardType="default"
               id={topic.id}
@@ -90,7 +90,7 @@ function TopicCardList({
               isBookmarked={topic.isBookmarked}
               getTopicsFromServer={getTopicsFromServer}
             />
-          </Fragment>
+          </ul>
         ))}
       </Grid>
     </Wrapper>

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -139,7 +139,13 @@ function TopicInfo({
           </Flex>
         </Flex>
         {canUpdate && (
-          <Box cursor="pointer" onClick={updateTopicInfo}>
+          <Box
+            cursor="pointer"
+            onClick={updateTopicInfo}
+            tabIndex={ARIA_FOCUS}
+            role="button"
+            aria-label="지도 정보 수정하기"
+          >
             <UpdateBtnSVG />
           </Box>
         )}

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -106,6 +106,7 @@ function TopicInfo({
         $objectFit="cover"
         radius="medium"
         $errorDefaultSrc={DEFAULT_TOPIC_IMAGE}
+        isAriaHidden
       />
 
       <Space size={1} />
@@ -115,14 +116,24 @@ function TopicInfo({
           <Flex $alignItems="center" width="72px">
             <SmallTopicPin />
             <Space size={0} />
-            <Text color="black" $fontSize="small" $fontWeight="normal">
+            <Text
+              color="black"
+              $fontSize="small"
+              $fontWeight="normal"
+              aria-hidden
+            >
               {topicPinCount > 999 ? '+999' : topicPinCount}개
             </Text>
           </Flex>
           <Flex $alignItems="center" width="72px">
             <SmallTopicStar />
             <Space size={0} />
-            <Text color="black" $fontSize="small" $fontWeight="normal">
+            <Text
+              color="black"
+              $fontSize="small"
+              $fontWeight="normal"
+              aria-hidden
+            >
               {topicBookmarkCount > 999 ? '+999' : topicBookmarkCount}명
             </Text>
           </Flex>
@@ -136,19 +147,41 @@ function TopicInfo({
 
       <Space size={0} />
 
-      <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
+      <Text
+        color="black"
+        $fontSize="extraLarge"
+        $fontWeight="bold"
+        aria-label={`지도 이름은 ${topicTitle} 이며`}
+      >
         {topicTitle}
       </Text>
       <Space size={1} />
-      <Text color="black" $fontSize="small" $fontWeight="normal">
+      <Text
+        color="black"
+        $fontSize="small"
+        $fontWeight="normal"
+        aria-label={`지도 작성자는 ${topicCreator} 입니다.`}
+      >
         {topicCreator}
       </Text>
       <Space size={1} />
-      <Text color="black" $fontSize="small" $fontWeight="normal">
+      <Text
+        color="black"
+        $fontSize="small"
+        $fontWeight="normal"
+        aria-label={`다음은 이 지도의 설명입니다. ${topicDescription}`}
+      >
         {topicDescription}
       </Text>
       <Space size={3} />
-      <Text color="gray" $fontSize="small" $fontWeight="normal">
+      <Text
+        color="gray"
+        $fontSize="small"
+        $fontWeight="normal"
+        aria-label={`이 지도의 마지막 업데이트는 ${topicUpdatedAt
+          .split('T')[0]
+          .replaceAll('-', '.')} 입니다.`}
+      >
         {topicUpdatedAt.split('T')[0].replaceAll('-', '.')} 업데이트
       </Text>
 

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -90,6 +90,7 @@ function TopicInfo({
 
   return (
     <Flex
+      as="article"
       position="relative"
       $flexDirection="column"
       $backgroundColor="white"

--- a/frontend/src/components/TopicInfo/index.tsx
+++ b/frontend/src/components/TopicInfo/index.tsx
@@ -9,7 +9,7 @@ import SeeTogetherSVG from '../../assets/topicInfo_seeTogetherBtn_filled.svg';
 import SeeTogetherNotFilledSVG from '../../assets/topicInfo_seeTogetherBtn_notFilled.svg';
 import TopicShareUrlSVG from '../../assets/topicInfo_shareUrl.svg';
 import UpdateBtnSVG from '../../assets/updateBtn.svg';
-import { DEFAULT_TOPIC_IMAGE } from '../../constants';
+import { ARIA_FOCUS, DEFAULT_TOPIC_IMAGE } from '../../constants';
 import useToast from '../../hooks/useToast';
 import AddFavorite from '../AddFavorite';
 import AddSeeTogether from '../AddSeeTogether';
@@ -210,7 +210,13 @@ function TopicInfo({
           {isBookmarked ? <FavoriteSVG /> : <FavoriteNotFilledSVG />}
         </AddFavorite>
         <Space size={5} />
-        <TopicShareUrlSVG cursor="pointer" onClick={copyContent} />
+        <TopicShareUrlSVG
+          cursor="pointer"
+          onClick={copyContent}
+          tabIndex={ARIA_FOCUS}
+          role="button"
+          aria-label="URL 주소 공유하기 버튼"
+        />
       </ButtonsWrapper>
 
       <Space size={3} />

--- a/frontend/src/components/common/CheckBox/index.tsx
+++ b/frontend/src/components/common/CheckBox/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 
+import { ARIA_FOCUS } from '../../../constants';
 import useKeyDown from '../../../hooks/useKeyDown';
 import Flex from '../Flex';
 
@@ -31,7 +32,7 @@ function Checkbox({ id, isAlreadyChecked, label, onChecked }: CheckboxProps) {
             id={label}
             checked={isChecked}
             onChange={updateCheckedMembers}
-            tabIndex={6}
+            tabIndex={ARIA_FOCUS}
             ref={elementRef}
             onKeyDown={onElementKeyDown}
           />

--- a/frontend/src/components/common/CheckBox/index.tsx
+++ b/frontend/src/components/common/CheckBox/index.tsx
@@ -66,7 +66,7 @@ const CheckboxInput = styled.input`
   height: 1.6em;
   border-radius: 0.15em;
   margin-right: 0.5em;
-  border: 0.15em solid ${({ theme }) => theme.color.primary};
+  border: 0.1em solid ${({ theme }) => theme.color.black};
   background-color: ${({ theme }) => theme.color.white};
   outline: none;
   cursor: pointer;
@@ -77,7 +77,7 @@ const CheckboxInput = styled.input`
     background-size: 100% 100%;
     background-position: 50%;
     background-repeat: no-repeat;
-    background-color: ${({ theme }) => theme.color.primary};
+    background-color: ${({ theme }) => theme.color.checked};
   }
 `;
 

--- a/frontend/src/components/common/Image/index.tsx
+++ b/frontend/src/components/common/Image/index.tsx
@@ -8,6 +8,7 @@ interface ImageProps extends ImgHTMLAttributes<HTMLImageElement> {
   $objectFit?: string;
   radius?: 'small' | 'medium' | '50%';
   ratio?: string;
+  isAriaHidden?: boolean;
 }
 
 export default function Image({
@@ -19,6 +20,7 @@ export default function Image({
   $errorDefaultSrc,
   radius,
   ratio,
+  isAriaHidden,
 }: ImageProps) {
   return (
     <StyledImage
@@ -32,6 +34,7 @@ export default function Image({
       onError={(e: SyntheticEvent<HTMLImageElement, Event>) => {
         if ($errorDefaultSrc) e.currentTarget.src = $errorDefaultSrc;
       }}
+      aria-hidden={isAriaHidden}
     />
   );
 }

--- a/frontend/src/components/common/Input/SingleComment.tsx
+++ b/frontend/src/components/common/Input/SingleComment.tsx
@@ -77,7 +77,6 @@ function SingleComment({
       await refetch(Number(pinDetail));
       showToast('info', '댓글이 삭제되었습니다.');
     } catch (e) {
-      console.error(e);
       showToast('error', '댓글을 다시 작성해주세요');
     }
   };
@@ -99,7 +98,6 @@ function SingleComment({
       setIsEditing(false);
       showToast('info', '댓글이 수정되었습니다.');
     } catch (e) {
-      console.error(e);
       showToast('error', '댓글을 다시 작성해주세요');
     }
   };

--- a/frontend/src/components/common/Input/SingleComment.tsx
+++ b/frontend/src/components/common/Input/SingleComment.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { deleteApi } from '../../../apis/deleteApi';
 import { postApi } from '../../../apis/postApi';
 import { putApi } from '../../../apis/putApi';
+import { ARIA_FOCUS } from '../../../constants';
 import useToast from '../../../hooks/useToast';
 import { ConfirmCommentButton, CustomInput } from '../../../pages/PinDetail';
 import Flex from '../Flex';
@@ -119,7 +120,13 @@ function SingleComment({
           <Flex $justifyContent="space-between">
             <div>
               <Writer>
-                <Text $fontSize="default" $fontWeight="bold" color="black">
+                <Text
+                  $fontSize="default"
+                  $fontWeight="bold"
+                  color="black"
+                  tabIndex={ARIA_FOCUS}
+                  aria-label={`댓글 작성자는 ${comment.creator} 이고 댓글 내용은 ${comment.content}입니다.`}
+                >
                   @{comment.creator}
                 </Text>
               </Writer>
@@ -131,6 +138,9 @@ function SingleComment({
                   color="gray"
                   $fontWeight="bold"
                   onClick={onClickModifyBtn}
+                  tabIndex={ARIA_FOCUS}
+                  role="button"
+                  aria-label="댓글 수정"
                 >
                   수정
                 </Text>
@@ -139,6 +149,9 @@ function SingleComment({
                   color="primary"
                   $fontWeight="bold"
                   onClick={onClickDeleteBtn}
+                  tabIndex={ARIA_FOCUS}
+                  role="button"
+                  aria-label="댓글 삭제"
                 >
                   삭제
                 </Text>
@@ -176,7 +189,13 @@ function SingleComment({
                 onClick={toggleReplyOpen}
                 style={{ cursor: 'pointer', marginBottom: '8px' }}
               >
-                <Text color="black" $fontSize="small" $fontWeight="bold">
+                <Text
+                  color="black"
+                  $fontSize="small"
+                  $fontWeight="bold"
+                  role="button"
+                  tabIndex={ARIA_FOCUS}
+                >
                   답글 작성
                 </Text>
               </div>
@@ -214,7 +233,10 @@ function SingleComment({
                 width="28px"
                 height="28px"
               />
-              <MoreReplyButton onClick={toggleSeeMore}>
+              <MoreReplyButton
+                onClick={toggleSeeMore}
+                aria-label={seeMore ? '답글 숨기기' : '답글 보기'}
+              >
                 {seeMore ? '\u25B2' : '\u25BC'} 답글 {replyCount}개
               </MoreReplyButton>
             </Flex>

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -13,3 +13,5 @@ export const DEFAULT_PROD_URL =
   process.env.APP_URL || 'https://mapbefine.kro.kr/api';
 
 export const PIN_SIZE = 60;
+
+export const ARIA_FOCUS = 0;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -10,7 +10,7 @@ export const DEFAULT_PROFILE_IMAGE =
   'https://dr702blqc4x5d.cloudfront.net/2023-map-be-fine/icon/profile_defaultImage.svg';
 
 export const DEFAULT_PROD_URL =
-  process.env.APP_URL || 'https://mapbefine.kro.kr/api';
+  process.env.APP_URL || 'https://mapbefine.com/api';
 
 export const PIN_SIZE = 60;
 

--- a/frontend/src/hooks/useAriaLive.ts
+++ b/frontend/src/hooks/useAriaLive.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+
+interface Props {
+  liveTagId: string;
+  defaultAnnounceText: string;
+}
+
+const useAriaLive = ({ liveTagId = '', defaultAnnounceText = '' }: Props) => {
+  const [announceText, setAnnounceText] = useState(defaultAnnounceText);
+
+  const setAriaLiveTagInnerText = (text: string) => {
+    setAnnounceText(text);
+  };
+
+  useEffect(() => {
+    if (announceText) {
+      const ariaLiveTag = document.getElementById(liveTagId);
+
+      if (ariaLiveTag) {
+        ariaLiveTag.innerText = announceText;
+      }
+    }
+  }, [announceText]);
+
+  return { setAriaLiveTagInnerText };
+};
+
+export default useAriaLive;

--- a/frontend/src/pages/AskLogin.tsx
+++ b/frontend/src/pages/AskLogin.tsx
@@ -19,6 +19,7 @@ function AskLogin() {
 
   return (
     <Flex
+      as="section"
       $flexDirection="column"
       $justifyContent="center"
       $alignItems="center"

--- a/frontend/src/pages/Bookmark.tsx
+++ b/frontend/src/pages/Bookmark.tsx
@@ -8,7 +8,7 @@ import Space from '../components/common/Space';
 import MediaSpace from '../components/common/Space/MediaSpace';
 import MediaText from '../components/common/Text/MediaText';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
-import { FULLSCREEN } from '../constants';
+import { ARIA_FOCUS, FULLSCREEN } from '../constants';
 import useNavigator from '../hooks/useNavigator';
 import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
@@ -34,17 +34,13 @@ function Bookmark() {
             color="black"
             $fontSize="extraLarge"
             $fontWeight="bold"
-            tabIndex={0}
+            tabIndex={ARIA_FOCUS}
+            aria-label="즐겨찾기 페이지 입니다. 즐겨찾기한 지도들을 확인할 수 있습니다."
           >
             즐겨찾기
           </MediaText>
           <Space size={0} />
-          <MediaText
-            color="gray"
-            $fontSize="default"
-            $fontWeight="normal"
-            tabIndex={1}
-          >
+          <MediaText color="gray" $fontSize="default" $fontWeight="normal">
             즐겨찾기한 지도들을 한 눈에 보세요.
           </MediaText>
         </Box>

--- a/frontend/src/pages/Bookmark.tsx
+++ b/frontend/src/pages/Bookmark.tsx
@@ -30,6 +30,7 @@ function Bookmark() {
       <Flex $justifyContent="space-between" $alignItems="flex-end">
         <Box>
           <MediaText
+            as="h2"
             color="black"
             $fontSize="extraLarge"
             $fontWeight="bold"
@@ -68,7 +69,7 @@ function Bookmark() {
   );
 }
 
-const Wrapper = styled.article`
+const Wrapper = styled.section`
   width: 1140px;
   margin: 0 auto;
   position: relative;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -90,7 +90,7 @@ function Home() {
   );
 }
 
-const Wrapper = styled.article`
+const Wrapper = styled.div`
   width: 1140px;
   margin: 0 auto;
   position: relative;

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -223,7 +223,7 @@ function NewPin() {
           width={`calc(${width} - ${LAYOUT_PADDING})`}
           $flexDirection="column"
         >
-          <Text color="black" $fontSize="large" $fontWeight="bold">
+          <Text as="h3" color="black" $fontSize="large" $fontWeight="bold">
             핀 생성
           </Text>
 

--- a/frontend/src/pages/NewPin.tsx
+++ b/frontend/src/pages/NewPin.tsx
@@ -13,7 +13,7 @@ import Text from '../components/common/Text';
 import InputContainer from '../components/InputContainer';
 import Modal from '../components/Modal';
 import ModalMyTopicList from '../components/ModalMyTopicList';
-import { LAYOUT_PADDING, SIDEBAR } from '../constants';
+import { ARIA_FOCUS, LAYOUT_PADDING, SIDEBAR } from '../constants';
 import { CoordinatesContext } from '../context/CoordinatesContext';
 import { MarkerContext } from '../context/MarkerContext';
 import { ModalContext } from '../context/ModalContext';
@@ -223,7 +223,14 @@ function NewPin() {
           width={`calc(${width} - ${LAYOUT_PADDING})`}
           $flexDirection="column"
         >
-          <Text as="h3" color="black" $fontSize="large" $fontWeight="bold">
+          <Text
+            as="h3"
+            color="black"
+            $fontSize="large"
+            $fontWeight="bold"
+            tabIndex={ARIA_FOCUS}
+            aria-label="장소 생성 페이지입니다. 아래 항목을 입력하세요."
+          >
             핀 생성
           </Text>
 
@@ -260,7 +267,13 @@ function NewPin() {
           </Text>
           <Space size={0} />
           <Flex>
-            <ImageInputLabel htmlFor="file">파일 찾기</ImageInputLabel>
+            <ImageInputLabel
+              htmlFor="file"
+              tabIndex={ARIA_FOCUS}
+              aria-label="장소에 해당하는 사진을 선택해주세요."
+            >
+              파일 찾기
+            </ImageInputLabel>
             <ImageInputButton
               id="file"
               type="file"
@@ -289,7 +302,7 @@ function NewPin() {
             value={formValues.name}
             placeholder="50글자 이내로 장소의 이름을 입력해주세요."
             onChangeInput={onChangeInput}
-            tabIndex={1}
+            tabIndex={ARIA_FOCUS}
             errorMessage={errorMessages.name}
             maxLength={50}
           />
@@ -321,7 +334,7 @@ function NewPin() {
             value={formValues.description}
             placeholder="1000자 이내로 장소에 대한 의견을 남겨주세요."
             onChangeInput={onChangeInput}
-            tabIndex={3}
+            tabIndex={ARIA_FOCUS}
             errorMessage={errorMessages.description}
             maxLength={1000}
           />
@@ -330,7 +343,8 @@ function NewPin() {
 
           <Flex $justifyContent="end">
             <Button
-              tabIndex={5}
+              tabIndex={ARIA_FOCUS}
+              aria-label="장소 생성 취소하기"
               type="button"
               variant="secondary"
               onClick={goToBack}
@@ -338,7 +352,11 @@ function NewPin() {
               취소하기
             </Button>
             <Space size={3} />
-            <Button tabIndex={4} variant="primary">
+            <Button
+              tabIndex={ARIA_FOCUS}
+              aria-label="장소 생성하기"
+              variant="primary"
+            >
               추가하기
             </Button>
           </Flex>

--- a/frontend/src/pages/NewTopic.tsx
+++ b/frontend/src/pages/NewTopic.tsx
@@ -167,7 +167,7 @@ function NewTopic() {
         width={`calc(${width} - ${LAYOUT_PADDING})`}
         $flexDirection="column"
       >
-        <Text color="black" $fontSize="large" $fontWeight="bold">
+        <Text as="h3" color="black" $fontSize="large" $fontWeight="bold">
           지도 생성
         </Text>
 

--- a/frontend/src/pages/NewTopic.tsx
+++ b/frontend/src/pages/NewTopic.tsx
@@ -9,7 +9,7 @@ import Flex from '../components/common/Flex';
 import Space from '../components/common/Space';
 import Text from '../components/common/Text';
 import InputContainer from '../components/InputContainer';
-import { LAYOUT_PADDING, SIDEBAR } from '../constants';
+import { ARIA_FOCUS, LAYOUT_PADDING, SIDEBAR } from '../constants';
 import { MarkerContext } from '../context/MarkerContext';
 import { TagContext } from '../context/TagContext';
 import useCompressImage from '../hooks/useCompressImage';
@@ -167,7 +167,14 @@ function NewTopic() {
         width={`calc(${width} - ${LAYOUT_PADDING})`}
         $flexDirection="column"
       >
-        <Text as="h3" color="black" $fontSize="large" $fontWeight="bold">
+        <Text
+          as="h3"
+          color="black"
+          $fontSize="large"
+          $fontWeight="bold"
+          tabIndex={ARIA_FOCUS}
+          aria-label="지도 생성 페이지입니다. 아래 항목을 입력하세요."
+        >
           지도 생성
         </Text>
 
@@ -187,7 +194,14 @@ function NewTopic() {
             </>
           )}
 
-          <ImageInputLabel htmlFor="file">파일 찾기</ImageInputLabel>
+          <ImageInputLabel
+            htmlFor="file"
+            role="button"
+            tabIndex={ARIA_FOCUS}
+            aria-label="지도를 대표하는 사진을 선택해주세요."
+          >
+            파일 찾기
+          </ImageInputLabel>
           <ImageInputButton
             id="file"
             type="file"
@@ -206,7 +220,7 @@ function NewTopic() {
           value={formValues.name}
           placeholder="20자 이내로 지도의 이름을 입력해주세요."
           onChangeInput={onChangeInput}
-          tabIndex={2}
+          tabIndex={ARIA_FOCUS}
           errorMessage={errorMessages.name}
           maxLength={20}
         />
@@ -221,7 +235,7 @@ function NewTopic() {
           value={formValues.description}
           placeholder="100글자 이내로 지도에 대해서 설명해주세요."
           onChangeInput={onChangeInput}
-          tabIndex={3}
+          tabIndex={ARIA_FOCUS}
           errorMessage={errorMessages.description}
           maxLength={100}
         />
@@ -241,7 +255,8 @@ function NewTopic() {
 
         <Flex $justifyContent="end">
           <Button
-            tabIndex={7}
+            tabIndex={ARIA_FOCUS}
+            aria-label="지도 생성 취소하기"
             type="button"
             variant="secondary"
             onClick={goToBack}
@@ -250,7 +265,8 @@ function NewTopic() {
           </Button>
           <Space size={3} />
           <Button
-            tabIndex={7}
+            tabIndex={ARIA_FOCUS}
+            aria-label="지도 생성하기"
             variant="primary"
             onClick={() => {
               setTags([]);

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -14,7 +14,8 @@ function NotFound() {
   useSetLayoutWidth(FULLSCREEN);
 
   return (
-    <NotFoundContainer
+    <Wrapper
+      as="section"
       $justifyContent="center"
       $alignItems="center"
       width="100vw"
@@ -38,11 +39,11 @@ function NotFound() {
           메인페이지로 가기
         </NotFoundButton>
       </Flex>
-    </NotFoundContainer>
+    </Wrapper>
   );
 }
 
-const NotFoundContainer = styled(Flex)`
+const Wrapper = styled(Flex)`
   flex-direction: row;
   @media screen and (max-width: 700px) {
     flex-direction: column;

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -183,7 +183,7 @@ function PinDetail({
   return (
     <Wrapper $layoutWidth={width} $selectedPinId={pinId} data-cy="pin-detail">
       <Flex $justifyContent="space-between" $alignItems="baseline" width="100%">
-        <Text color="black" $fontSize="extraLarge" $fontWeight="bold">
+        <Text as="h2" color="black" $fontSize="extraLarge" $fontWeight="bold">
           {pin.name}
         </Text>
       </Flex>
@@ -218,7 +218,7 @@ function PinDetail({
       <PinImageContainer images={pin.images} getPinData={getPinData} />
       <Space size={6} />
       <Flex $flexDirection="column">
-        <Text color="black" $fontSize="large" $fontWeight="bold">
+        <Text as="h3" color="black" $fontSize="large" $fontWeight="bold">
           어디에 있나요?
         </Text>
         <Space size={1} />
@@ -227,7 +227,7 @@ function PinDetail({
         </Text>
       </Flex>
       <Space size={6} />
-      <Flex $flexDirection="column">
+      <Flex as="h3" $flexDirection="column">
         <Text color="black" $fontSize="large" $fontWeight="bold">
           어떤 곳인가요?
         </Text>
@@ -252,8 +252,8 @@ function PinDetail({
 
       {/*  Comment Section */}
 
-      <Text color="black" $fontSize="large" $fontWeight="bold">
-        어떻게 생각하나요?{' '}
+      <Text as="h3" color="black" $fontSize="large" $fontWeight="bold">
+        어떻게 생각하나요?
       </Text>
       <Space size={1} />
       {userToken && (

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -208,7 +208,12 @@ function PinDetail({
         </Text>
         <Flex $flexDirection="column" $alignItems="flex-end">
           {pin.canUpdate ? (
-            <Box cursor="pointer">
+            <Box
+              cursor="pointer"
+              tabIndex={ARIA_FOCUS}
+              role="button"
+              aria-label="장소 정보 수정하기"
+            >
               <UpdateBtnSVG onClick={onClickEditPin} />
             </Box>
           ) : (

--- a/frontend/src/pages/PinDetail.tsx
+++ b/frontend/src/pages/PinDetail.tsx
@@ -16,6 +16,7 @@ import Text from '../components/common/Text';
 import Modal from '../components/Modal';
 import AddToMyTopicList from '../components/ModalMyTopicList/addToMyTopicList';
 import PinImageContainer from '../components/PinImageContainer';
+import { ARIA_FOCUS } from '../constants';
 import { ModalContext } from '../context/ModalContext';
 import useCompressImage from '../hooks/useCompressImage';
 import useFormValues from '../hooks/useFormValues';
@@ -183,13 +184,26 @@ function PinDetail({
   return (
     <Wrapper $layoutWidth={width} $selectedPinId={pinId} data-cy="pin-detail">
       <Flex $justifyContent="space-between" $alignItems="baseline" width="100%">
-        <Text as="h2" color="black" $fontSize="extraLarge" $fontWeight="bold">
+        <Text
+          as="h2"
+          color="black"
+          $fontSize="extraLarge"
+          $fontWeight="bold"
+          tabIndex={ARIA_FOCUS}
+          aria-label={`장소 이름은 ${pin.name} 입니다.`}
+        >
           {pin.name}
         </Text>
       </Flex>
       <Space size={1} />
       <Flex $justifyContent="space-between" $alignItems="flex-end" width="100%">
-        <Text color="black" $fontSize="small" $fontWeight="normal">
+        <Text
+          color="black"
+          $fontSize="small"
+          $fontWeight="normal"
+          tabIndex={ARIA_FOCUS}
+          aria-label={`장소 작성자는 ${pin.creator} 입니다.`}
+        >
           {pin.creator}
         </Text>
         <Flex $flexDirection="column" $alignItems="flex-end">
@@ -200,7 +214,16 @@ function PinDetail({
           ) : (
             <Space size={5} />
           )}
-          <Text color="black" $fontSize="small" $fontWeight="normal">
+          <Text
+            color="black"
+            $fontSize="small"
+            $fontWeight="normal"
+            tabIndex={ARIA_FOCUS}
+            aria-label={`마지막 수정일자는 ${pin.updatedAt
+              .split('T')[0]
+              .split('-')
+              .join('.')} 입니다.`}
+          >
             {pin.updatedAt.split('T')[0].split('-').join('.')}
           </Text>
         </Flex>
@@ -222,7 +245,13 @@ function PinDetail({
           어디에 있나요?
         </Text>
         <Space size={1} />
-        <Text color="black" $fontSize="default" $fontWeight="normal">
+        <Text
+          color="black"
+          $fontSize="default"
+          $fontWeight="normal"
+          tabIndex={ARIA_FOCUS}
+          aria-label={`장소의 위치는 ${pin.address} 입니다.`}
+        >
           {pin.address}
         </Text>
       </Flex>
@@ -232,7 +261,13 @@ function PinDetail({
           어떤 곳인가요?
         </Text>
         <Space size={1} />
-        <Text color="black" $fontSize="default" $fontWeight="normal">
+        <Text
+          color="black"
+          $fontSize="default"
+          $fontWeight="normal"
+          tabIndex={ARIA_FOCUS}
+          aria-label={`장소에 대한 설명은 다음과 같습니다. ${pin.description}`}
+        >
           {pin.description}
         </Text>
       </Flex>
@@ -243,7 +278,11 @@ function PinDetail({
           내 지도에 저장하기
         </SaveToMyMapButton>
         <Space size={3} />
-        <ShareButton variant="secondary" onClick={copyContent}>
+        <ShareButton
+          variant="secondary"
+          onClick={copyContent}
+          aria-label="URL 공유하기 "
+        >
           공유하기
         </ShareButton>
       </ButtonsWrapper>
@@ -265,11 +304,13 @@ function PinDetail({
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setNewComment(e.target.value)
               }
+              aria-label="댓글을 추가하려면 텍스트를 입력하세요."
               placeholder="댓글 추가"
             />
             <ConfirmCommentButton
               variant="secondary"
               onClick={onClickCommentBtn}
+              aria-label="댓글 등록"
             >
               등록
             </ConfirmCommentButton>

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -8,7 +8,7 @@ import MediaSpace from '../components/common/Space/MediaSpace';
 import MediaText from '../components/common/Text/MediaText';
 import MyInfo from '../components/MyInfo';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
-import { FULLSCREEN } from '../constants';
+import { ARIA_FOCUS, FULLSCREEN } from '../constants';
 import useNavigator from '../hooks/useNavigator';
 import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
@@ -35,20 +35,17 @@ function Profile() {
       <Flex $justifyContent="space-between" $alignItems="flex-end">
         <Box>
           <MediaText
+            as="h2"
             color="black"
             $fontSize="extraLarge"
             $fontWeight="bold"
-            tabIndex={0}
+            tabIndex={ARIA_FOCUS}
+            aria-label="나의 지도 영역입니다. 내가 만든 지도들을 확인할 수 있습니다."
           >
             나의 지도
           </MediaText>
           <Space size={0} />
-          <MediaText
-            color="gray"
-            $fontSize="default"
-            $fontWeight="normal"
-            tabIndex={1}
-          >
+          <MediaText color="gray" $fontSize="default" $fontWeight="normal">
             내가 만든 지도를 확인해보세요.
           </MediaText>
         </Box>

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -10,10 +10,15 @@ import Space from '../components/common/Space';
 import MediaText from '../components/common/Text/MediaText';
 import SearchBar from '../components/SearchBar/SearchBar';
 import TopicCard from '../components/TopicCard';
+import { FULLSCREEN } from '../constants';
+import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
+import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
 import { TopicCardProps } from '../types/Topic';
 
 function Search() {
   const { fetchGet } = useGet();
+  useSetLayoutWidth(FULLSCREEN);
+  useSetNavbarHighlight('none');
 
   const [originalTopics, setOriginalTopics] = useState<TopicCardProps[] | null>(
     null,

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -58,6 +58,7 @@ function Search() {
       <Flex $justifyContent="space-between" $alignItems="flex-end">
         <Box>
           <MediaText
+            as="h2"
             color="black"
             $fontSize="extraLarge"
             $fontWeight="bold"
@@ -128,7 +129,7 @@ function Search() {
 
 export default Search;
 
-const Wrapper = styled.article`
+const Wrapper = styled.section`
   width: 1140px;
   margin: 0 auto;
   position: relative;

--- a/frontend/src/pages/SeeAllLatestTopics.tsx
+++ b/frontend/src/pages/SeeAllLatestTopics.tsx
@@ -23,9 +23,14 @@ function SeeAllLatestTopics() {
   };
 
   return (
-    <Wrapper>
+    <Wrapper as="section">
       <Space size={5} />
-      <MediaText color="black" $fontSize="extraLarge" $fontWeight="bold">
+      <MediaText
+        as="h2"
+        color="black"
+        $fontSize="extraLarge"
+        $fontWeight="bold"
+      >
         새로울 지도?
       </MediaText>
 

--- a/frontend/src/pages/SeeAllLatestTopics.tsx
+++ b/frontend/src/pages/SeeAllLatestTopics.tsx
@@ -6,7 +6,7 @@ import Space from '../components/common/Space';
 import MediaSpace from '../components/common/Space/MediaSpace';
 import MediaText from '../components/common/Text/MediaText';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
-import { FULLSCREEN } from '../constants';
+import { ARIA_FOCUS, FULLSCREEN } from '../constants';
 import useNavigator from '../hooks/useNavigator';
 import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
@@ -30,6 +30,8 @@ function SeeAllLatestTopics() {
         color="black"
         $fontSize="extraLarge"
         $fontWeight="bold"
+        tabIndex={ARIA_FOCUS}
+        aria-label="새로울 지도 전체보기 페이지 입니다."
       >
         새로울 지도?
       </MediaText>

--- a/frontend/src/pages/SeeAllNearTopics.tsx
+++ b/frontend/src/pages/SeeAllNearTopics.tsx
@@ -23,9 +23,14 @@ function SeeAllNearTopics() {
   };
 
   return (
-    <Wrapper>
+    <Wrapper as="section">
       <Space size={5} />
-      <MediaText color="black" $fontSize="extraLarge" $fontWeight="bold">
+      <MediaText
+        as="h2"
+        color="black"
+        $fontSize="extraLarge"
+        $fontWeight="bold"
+      >
         내 주변일 지도?
       </MediaText>
 

--- a/frontend/src/pages/SeeAllNearTopics.tsx
+++ b/frontend/src/pages/SeeAllNearTopics.tsx
@@ -6,7 +6,7 @@ import Space from '../components/common/Space';
 import MediaSpace from '../components/common/Space/MediaSpace';
 import MediaText from '../components/common/Text/MediaText';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
-import { FULLSCREEN } from '../constants';
+import { ARIA_FOCUS, FULLSCREEN } from '../constants';
 import useNavigator from '../hooks/useNavigator';
 import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
@@ -30,8 +30,10 @@ function SeeAllNearTopics() {
         color="black"
         $fontSize="extraLarge"
         $fontWeight="bold"
+        tabIndex={ARIA_FOCUS}
+        aria-label="모두일 지도 전체보기 페이지 입니다."
       >
-        내 주변일 지도?
+        모두일 지도?
       </MediaText>
 
       <MediaSpace size={6} />

--- a/frontend/src/pages/SeeAllPopularTopics.tsx
+++ b/frontend/src/pages/SeeAllPopularTopics.tsx
@@ -6,7 +6,7 @@ import Space from '../components/common/Space';
 import MediaSpace from '../components/common/Space/MediaSpace';
 import MediaText from '../components/common/Text/MediaText';
 import TopicCardContainerSkeleton from '../components/Skeletons/TopicListSkeleton';
-import { FULLSCREEN } from '../constants';
+import { ARIA_FOCUS, FULLSCREEN } from '../constants';
 import useNavigator from '../hooks/useNavigator';
 import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
@@ -30,6 +30,8 @@ function SeeAllTopics() {
         color="black"
         $fontSize="extraLarge"
         $fontWeight="bold"
+        tabIndex={ARIA_FOCUS}
+        aria-label="인기 급상승할 지도 전체보기 페이지 입니다."
       >
         인기 급상승할 지도?
       </MediaText>

--- a/frontend/src/pages/SeeAllPopularTopics.tsx
+++ b/frontend/src/pages/SeeAllPopularTopics.tsx
@@ -23,9 +23,14 @@ function SeeAllTopics() {
   };
 
   return (
-    <Wrapper>
+    <Wrapper as="section">
       <Space size={5} />
-      <MediaText color="black" $fontSize="extraLarge" $fontWeight="bold">
+      <MediaText
+        as="h2"
+        color="black"
+        $fontSize="extraLarge"
+        $fontWeight="bold"
+      >
         인기 급상승할 지도?
       </MediaText>
 

--- a/frontend/src/pages/SelectedTopic.tsx
+++ b/frontend/src/pages/SelectedTopic.tsx
@@ -27,7 +27,7 @@ function SelectedTopic() {
   const [selectedPinId, setSelectedPinId] = useState<number | null>(null);
   const [isOpen, setIsOpen] = useState(true);
   const [isEditPinDetail, setIsEditPinDetail] = useState<boolean>(false);
-  const { coordinates, setCoordinates } = useContext(CoordinatesContext);
+  const { setCoordinates } = useContext(CoordinatesContext);
   const { width } = useSetLayoutWidth(SIDEBAR);
   const zoomTimerIdRef = useRef<NodeJS.Timeout | null>(null);
   const dragTimerIdRef = useRef<NodeJS.Timeout | null>(null);
@@ -170,6 +170,7 @@ function SelectedTopic() {
             onClick={() => {
               setIsOpen(!isOpen);
             }}
+            aria-label={`장소 상세 설명 버튼 ${isOpen ? '닫기' : '열기'}`}
           >
             ◀
           </ToggleButton>

--- a/frontend/src/themes/color.ts
+++ b/frontend/src/themes/color.ts
@@ -2,11 +2,11 @@ const color = {
   primary: '#E1325C',
   black: '#454545',
   white: '#FFFFFF',
-
   darkGray: '#767676',
   gray: '#969696',
   lightGray: '#E7E7E7',
   whiteGray: '#F9F9F9',
+  checked: '#287EFF',
 } as const;
 
 export type colorThemeKey = keyof typeof color;


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
* 서비스 전체 태그를 대상으로 시맨틱 태그 작업
* 서비스 전체 플로우를 대상으로 접근성 로직 유지보수
* PinPreview 체크 박스와 친구추가 모달 체크 박스 UI 통일화

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
### 시맨틱 태그
* 커밋 로그에서도 볼 수 있듯이 시맨틱 태그를 보완했습니다. article과 section 경계면이 모호하여 topicCard와 같이 독단적으로 쓰일 수 있는 컴포넌트는 모두 article 태그로 지정하고, 영역을 나타내는 곳을 section으로 지정하였습니다.
* 머리말 (예를 들면, 인기 급상승할 지도? 새로울 지도? 등) 영역은 h2, h3 태그를 사용하여 보다 페이지를 대표하는 머리말 역할을 할 수 있도록 하였습니다.

### 웹 접근성
* 서비스 전반 플로우에 대하여 aria-label, role, tabIndex, aria-hidden 등을 사용하여 접근성 로직을 유지보수 하였습니다. 
* SVG 아이콘이자 버튼의 기능을 하는 것들 대부분이 포커스가 누락되어 있어서 이를 보완하였습니다.
* 지도 추가, 핀 추가 페이지에 접근성 로직이 누락되어 이를 보완하였습니다. 핀 추가 페이지의 경우 핀이란 도메인 단어 대신 장소로 일괄 수정하였습니다.
* 핀 상세보기 페이지에 접근성 로직이 누락되어 이를 보완하였습니다.
* 장소 댓글 부분에서 접근성 로직이 누락되어 이를 보완하였습니다.

### 웹 표준
* 크로스 브라우징 이슈는 딱히 없었습니다만, 사파리 브라우저에서 checkbox UI가 크게 달라지는 부분이 있어서 이를 @아이크 가 이전에 작업했던 친구들에게 권한 추가 모달의 checkbox UI를 가져와 적용하였습니다. 체크 박스 색이 primary 로 되어 있던 것을 checked 라는 칼라로 새로 지정하였습니다.

## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
* 개발 서버 API가 없어졌으므로 운영 서버 API로 변경하였습니다. 테스트 시 이 점 유의해주세요.
* 접근성 로직에서 PinPreview를 클릭하여 PinDetail 페이지로 넘어가는게 자연스러운 플로우지만 포커스가 순차 적용되어있기에 이 부분이 미흡합니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->

<!-- closed #번호 --> 
close #628 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
