### PR TITLE
[FE] Refactor/#645: Home 페이지 API 로직 수정 및 React-Query 적용

### DIFF
--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,0 +1,35 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+const API_POSTFIX = 'api';
+const BASE_URL = process.env.APP_URL || `https://mapbefine.com/${API_POSTFIX}`;
+
+const axiosInstance = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    Authorization: `Bearer ${localStorage.getItem('userToken')}`,
+  },
+});
+
+export interface HttpClient extends AxiosInstance {
+  get<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>;
+  post<T = unknown>(
+    url: string,
+    data?: any,
+    config?: AxiosRequestConfig,
+  ): Promise<T>;
+  patch<T = unknown>(
+    url: string,
+    data?: any,
+    config?: AxiosRequestConfig,
+  ): Promise<T>;
+  put<T = unknown>(
+    url: string,
+    data?: any,
+    config?: AxiosRequestConfig,
+  ): Promise<T>;
+  delete<T = unknown>(url: string, config?: AxiosRequestConfig): Promise<T>;
+}
+
+export const http: HttpClient = axiosInstance;
+
+http.interceptors.response.use((res) => res.data);

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -3,11 +3,11 @@ import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 const API_POSTFIX = 'api';
 const BASE_URL = process.env.APP_URL || `https://mapbefine.com/${API_POSTFIX}`;
 
+const token = localStorage.getItem('userToken');
+
 const axiosInstance = axios.create({
   baseURL: BASE_URL,
-  headers: {
-    Authorization: `Bearer ${localStorage.getItem('userToken')}`,
-  },
+  headers: token ? { Authorization: `Bearer ${token}` } : {},
 });
 
 export interface HttpClient extends AxiosInstance {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,4 @@
+import { TopicCardProps } from '../types/Topic';
+import { http } from './http';
+
+export const getTopics = (url: string) => http.get<TopicCardProps[]>(url);

--- a/frontend/src/components/TopicCard/index.tsx
+++ b/frontend/src/components/TopicCard/index.tsx
@@ -1,4 +1,5 @@
-import { SyntheticEvent, useContext, useState } from 'react';
+import { QueryObserverResult, RefetchOptions } from '@tanstack/react-query';
+import { useContext, useState } from 'react';
 import { styled } from 'styled-components';
 
 import SeeTogetherSVG from '../../assets/seeTogetherBtn_filled.svg';
@@ -26,7 +27,9 @@ interface OnClickDesignatedProps {
 interface TopicCardExtendedProps extends TopicCardProps {
   cardType: 'default' | 'modal';
   onClickDesignated?: ({ topicId, topicName }: OnClickDesignatedProps) => void;
-  getTopicsFromServer?: () => void;
+  getTopicsFromServer?: (
+    options?: RefetchOptions | undefined,
+  ) => Promise<QueryObserverResult<TopicCardProps[], Error>>;
 }
 
 function TopicCard({
@@ -39,7 +42,6 @@ function TopicCard({
   pinCount,
   bookmarkCount,
   isInAtlas,
-  isBookmarked,
   onClickDesignated,
   getTopicsFromServer,
 }: TopicCardExtendedProps) {

--- a/frontend/src/components/TopicCardContainer/index.tsx
+++ b/frontend/src/components/TopicCardContainer/index.tsx
@@ -1,11 +1,8 @@
 import { Swiper, Tab } from 'map-befine-swiper';
-import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 
-import useGet from '../../apiHooks/useGet';
 import useTopicsQuery from '../../hooks/api/useTopicsQuery';
 import useKeyDown from '../../hooks/useKeyDown';
-import { TopicCardProps } from '../../types/Topic';
 import Box from '../common/Box';
 import Flex from '../common/Flex';
 import Space from '../common/Space';
@@ -26,20 +23,8 @@ function TopicCardContainer({
   containerDescription,
   routeWhenSeeAll,
 }: TopicCardContainerProps) {
-  const [_, setTopics] = useState<TopicCardProps[] | null>(null);
+  const { topics, refetchTopics } = useTopicsQuery(url);
   const { elementRef, onElementKeyDown } = useKeyDown<HTMLSpanElement>();
-  const { fetchGet } = useGet();
-
-  const setTopicsFromServer = async () => {
-    await fetchGet<TopicCardProps[]>(
-      url,
-      '지도를 가져오는데 실패했습니다. 잠시 후 다시 시도해주세요.',
-      (response) => {
-        setTopics(response);
-      },
-    );
-  };
-  const { topics } = useTopicsQuery(url);
 
   return (
     <section>
@@ -110,7 +95,7 @@ function TopicCardContainer({
                       bookmarkCount={topic.bookmarkCount}
                       isInAtlas={topic.isInAtlas}
                       isBookmarked={topic.isBookmarked}
-                      getTopicsFromServer={setTopicsFromServer}
+                      getTopicsFromServer={refetchTopics}
                     />
                     <CustomSpace />
                   </Flex>

--- a/frontend/src/components/TopicCardContainer/index.tsx
+++ b/frontend/src/components/TopicCardContainer/index.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { styled } from 'styled-components';
 
 import useGet from '../../apiHooks/useGet';
+import useTopicsQuery from '../../hooks/api/useTopicsQuery';
 import useKeyDown from '../../hooks/useKeyDown';
 import { TopicCardProps } from '../../types/Topic';
 import Box from '../common/Box';
@@ -25,7 +26,7 @@ function TopicCardContainer({
   containerDescription,
   routeWhenSeeAll,
 }: TopicCardContainerProps) {
-  const [topics, setTopics] = useState<TopicCardProps[] | null>(null);
+  const [_, setTopics] = useState<TopicCardProps[] | null>(null);
   const { elementRef, onElementKeyDown } = useKeyDown<HTMLSpanElement>();
   const { fetchGet } = useGet();
 
@@ -38,10 +39,7 @@ function TopicCardContainer({
       },
     );
   };
-
-  useEffect(() => {
-    setTopicsFromServer();
-  }, []);
+  const { topics } = useTopicsQuery(url);
 
   return (
     <section>

--- a/frontend/src/hooks/api/useTopicsQuery.ts
+++ b/frontend/src/hooks/api/useTopicsQuery.ts
@@ -3,11 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { getTopics } from '../../api';
 
 const useTopicsQuery = (url: string) => {
-  const { data: topics } = useQuery({
+  const { data: topics, refetch: refetchTopics } = useQuery({
     queryKey: ['topics', url],
     queryFn: () => getTopics(url),
   });
-  return { topics };
+  return { topics, refetchTopics };
 };
 
 export default useTopicsQuery;

--- a/frontend/src/hooks/api/useTopicsQuery.ts
+++ b/frontend/src/hooks/api/useTopicsQuery.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getTopics } from '../../api';
+
+const useTopicsQuery = (url: string) => {
+  const { data: topics } = useQuery({
+    queryKey: ['topics', url],
+    queryFn: () => getTopics(url),
+  });
+  return { topics };
+};
+
+export default useTopicsQuery;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ReactDOM from 'react-dom/client';
 import ReactGA from 'react-ga4';
 import { ThemeProvider } from 'styled-components';
@@ -21,11 +22,15 @@ if (process.env.REACT_APP_GOOGLE_ANALYTICS) {
   ReactGA.initialize(process.env.REACT_APP_GOOGLE_ANALYTICS);
 }
 
+const queryClient = new QueryClient();
+
 root.render(
-  <ThemeProvider theme={theme}>
-    <GlobalStyle />
-    <ErrorBoundary fallback={NotFound}>
-      <App />
-    </ErrorBoundary>
-  </ThemeProvider>,
+  <QueryClientProvider client={queryClient}>
+    <ThemeProvider theme={theme}>
+      <GlobalStyle />
+      <ErrorBoundary fallback={NotFound}>
+        <App />
+      </ErrorBoundary>
+    </ThemeProvider>
+  </QueryClientProvider>,
 );


### PR DESCRIPTION
## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
- Home페이지 tanstack-query 및 axios 적용
## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- 새로운 api 폴더를 생성해서 http.ts와 index.ts 파일을 만들었습니다
- http.ts는 http메소드, index.ts는 지도들을 가져오는 getTopics함수가 있습니다
- 홈 화면에서 각각 데이터를 fetch하는 곳은 TopicListContainer의 TopicCardContainer라서 useState와 useEffect를 useQuery로 대체했습니다
- 이전에 자식 컴포넌트에 getTopicsFromServer로 넘겨주던 함수를 refetch로 대체했는데 문제 없는지???
## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
- 인기 급상승 지도의 지도1을 모아보기 해제하면 새로울지도의 지도1에 반영 안되는 문제
- getTopicsFromServer의 정확한 목적 헷갈리네여
- refetch로 대체가능하면 error랑 로딩 처리 어떻게 할지 정해보죠
## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
#645 
<!-- closed #번호 --> 
#645 
## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
https://github.com/ssi02014/react-query-tutorial