### PR TITLE
Refactor/#655: 토픽 단일 조회 페이지 레이어 분리

### DIFF
--- a/frontend/.prettierrc.js
+++ b/frontend/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
+  printWidth: 100,
   singleQuote: true,
 };

--- a/frontend/src/apis/new/index.ts
+++ b/frontend/src/apis/new/index.ts
@@ -1,7 +1,10 @@
-import { TopicCardProps } from '../../types/Topic';
+import { TopicCardProps, TopicDetailProps } from '../../types/Topic';
 import { http } from './http';
 
 export const getTopics = (url: string) => http.get<TopicCardProps[]>(url);
 
 export const getProfile = () =>
   http.get<TopicCardProps[] | null>('/members/my/topics');
+
+export const getTopicDetail = (topicId: string) =>
+  http.get<TopicDetailProps[]>(`/topics/ids?ids=${topicId}`);

--- a/frontend/src/apis/new/index.ts
+++ b/frontend/src/apis/new/index.ts
@@ -1,3 +1,4 @@
+import { ClusteredCoordinates } from '../../pages/SelectedTopic/types';
 import { TopicCardProps, TopicDetailProps } from '../../types/Topic';
 import { http } from './http';
 
@@ -8,3 +9,11 @@ export const getProfile = () =>
 
 export const getTopicDetail = (topicId: string) =>
   http.get<TopicDetailProps[]>(`/topics/ids?ids=${topicId}`);
+
+export const getClusteredCoordinates = (
+  topicId: string,
+  distanceOfPinSize: number,
+) =>
+  http.get<ClusteredCoordinates[]>(
+    `/topics/clusters?ids=${topicId}&image-diameter=${distanceOfPinSize}`,
+  );

--- a/frontend/src/hooks/useTags.ts
+++ b/frontend/src/hooks/useTags.ts
@@ -1,9 +1,13 @@
-import { useContext } from 'react';
+import { useContext, useEffect } from 'react';
 
 import { TagContext } from '../context/TagContext';
 import useNavigator from './useNavigator';
 
-const useTags = () => {
+interface Props {
+  isInitTags: boolean;
+}
+
+const useTags = ({ isInitTags }: Props) => {
   const { tags, setTags } = useContext(TagContext);
   const { routePage } = useNavigator();
 
@@ -15,7 +19,13 @@ const useTags = () => {
     setTags([]);
   };
 
-  return { tags, setTags, onClickInitTags, onClickCreateTopicWithTags };
+  useEffect(() => {
+    if (isInitTags) return;
+
+    setTags([]);
+  }, []);
+
+  return { tags, onClickInitTags, onClickCreateTopicWithTags };
 };
 
 export default useTags;

--- a/frontend/src/hooks/useTags.ts
+++ b/frontend/src/hooks/useTags.ts
@@ -20,9 +20,7 @@ const useTags = ({ isInitTags }: Props) => {
   };
 
   useEffect(() => {
-    if (isInitTags) return;
-
-    setTags([]);
+    if (isInitTags) setTags([]);
   }, []);
 
   return { tags, onClickInitTags, onClickCreateTopicWithTags };

--- a/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
+++ b/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
@@ -20,7 +20,6 @@ import PinDetail from '../PinDetail';
 const PinsOfTopic = lazy(() => import('../../components/PinsOfTopic'));
 
 function SelectedTopic() {
-  const { Tmapv3 } = window;
   const { topicId } = useParams();
   const [searchParams, _] = useSearchParams();
   const [topicDetail, setTopicDetail] = useState<TopicDetailProps | null>(null);

--- a/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
+++ b/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
@@ -1,17 +1,15 @@
-import { lazy, Suspense, useContext, useEffect, useRef, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { lazy, Suspense, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
 import Space from '../../components/common/Space';
 import PullPin from '../../components/PullPin';
 import PinsOfTopicSkeleton from '../../components/Skeletons/PinsOfTopicSkeleton';
 import { LAYOUT_PADDING, SIDEBAR } from '../../constants';
-import { CoordinatesContext } from '../../context/CoordinatesContext';
 import useResizeMap from '../../hooks/useResizeMap';
 import useSetLayoutWidth from '../../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../../hooks/useSetNavbarHighlight';
 import useTags from '../../hooks/useTags';
-import useMapStore from '../../store/mapInstance';
 import PinDetail from '../PinDetail';
 import useClusterCoordinates from './hooks/useClusterCoordinates';
 import useHandleMapInteraction from './hooks/useHandleMapInteraction';
@@ -24,8 +22,7 @@ function SelectedTopic() {
   const { topicId } = useParams() as { topicId: string };
   const [isEditPinDetail, setIsEditPinDetail] = useState<boolean>(false);
   const { width } = useSetLayoutWidth(SIDEBAR);
-
-  const { tags, setTags, onClickInitTags, onClickCreateTopicWithTags } = useTags();
+  const { tags, onClickInitTags, onClickCreateTopicWithTags } = useTags({ isInitTags: true });
   const { isDoubleSidebarOpen, selectedPinId, setIsDoubleSidebarOpen, setSelectedPinId } = useSetSelectedPinId();
   const { data: topicDetail, refetch: getTopicDetail } = useTopicDetailQuery(topicId);
   const setClusteredCoordinates = useClusterCoordinates(topicId);
@@ -36,10 +33,6 @@ function SelectedTopic() {
   });
   useSetNavbarHighlight('none');
   useResizeMap();
-
-  useEffect(() => {
-    setTags([]);
-  }, []);
 
   if (!topicId || !topicDetail) return <></>;
 

--- a/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
+++ b/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
@@ -15,19 +15,18 @@ import useMapStore from '../../store/mapInstance';
 import PinDetail from '../PinDetail';
 import useClusterCoordinates from './hooks/useClusterCoordinates';
 import useHandleMapInteraction from './hooks/useHandleMapInteraction';
+import useSetSelectedPinId from './hooks/useSetSelectedPinId';
 import useTopicDetailQuery from './hooks/useTopicDetailQuery';
 
 const PinsOfTopic = lazy(() => import('../../components/PinsOfTopic'));
 
 function SelectedTopic() {
   const { topicId } = useParams() as { topicId: string };
-  const [searchParams, _] = useSearchParams();
-  const [selectedPinId, setSelectedPinId] = useState<number | null>(null);
-  const [isOpen, setIsOpen] = useState(true);
   const [isEditPinDetail, setIsEditPinDetail] = useState<boolean>(false);
   const { width } = useSetLayoutWidth(SIDEBAR);
 
   const { tags, setTags, onClickInitTags, onClickCreateTopicWithTags } = useTags();
+  const { isDoubleSidebarOpen, selectedPinId, setIsDoubleSidebarOpen, setSelectedPinId } = useSetSelectedPinId();
   const { data: topicDetail, refetch: getTopicDetail } = useTopicDetailQuery(topicId);
   const setClusteredCoordinates = useClusterCoordinates(topicId);
 
@@ -41,18 +40,6 @@ function SelectedTopic() {
   useEffect(() => {
     setTags([]);
   }, []);
-
-  useEffect(() => {
-    const queryParams = new URLSearchParams(location.search);
-
-    if (queryParams.has('pinDetail')) {
-      setSelectedPinId(Number(queryParams.get('pinDetail')));
-      setIsOpen(true);
-      return;
-    }
-
-    setSelectedPinId(null);
-  }, [searchParams]);
 
   if (!topicId || !topicDetail) return <></>;
 
@@ -82,15 +69,15 @@ function SelectedTopic() {
       {selectedPinId && (
         <>
           <ToggleButton
-            $isCollapsed={!isOpen}
+            $isCollapsed={!isDoubleSidebarOpen}
             onClick={() => {
-              setIsOpen(!isOpen);
+              setIsDoubleSidebarOpen(!isDoubleSidebarOpen);
             }}
-            aria-label={`장소 상세 설명 버튼 ${isOpen ? '닫기' : '열기'}`}
+            aria-label={`장소 상세 설명 버튼 ${isDoubleSidebarOpen ? '닫기' : '열기'}`}
           >
             ◀
           </ToggleButton>
-          <PinDetailWrapper className={isOpen ? '' : 'collapsedPinDetail'}>
+          <PinDetailWrapper className={isDoubleSidebarOpen ? '' : 'collapsedPinDetail'}>
             <PinDetail
               width={width}
               pinId={selectedPinId}

--- a/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
+++ b/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
@@ -6,7 +6,7 @@ import { getApi } from '../../apis/getApi';
 import Space from '../../components/common/Space';
 import PullPin from '../../components/PullPin';
 import PinsOfTopicSkeleton from '../../components/Skeletons/PinsOfTopicSkeleton';
-import { LAYOUT_PADDING, PIN_SIZE, SIDEBAR } from '../../constants';
+import { LAYOUT_PADDING, SIDEBAR } from '../../constants';
 import { CoordinatesContext } from '../../context/CoordinatesContext';
 import useRealDistanceOfPin from '../../hooks/useRealDistanceOfPin';
 import useResizeMap from '../../hooks/useResizeMap';
@@ -14,15 +14,14 @@ import useSetLayoutWidth from '../../hooks/useSetLayoutWidth';
 import useSetNavbarHighlight from '../../hooks/useSetNavbarHighlight';
 import useTags from '../../hooks/useTags';
 import useMapStore from '../../store/mapInstance';
-import { TopicDetailProps } from '../../types/Topic';
 import PinDetail from '../PinDetail';
+import useTopicDetailQuery from './hooks/useTopicDetailQuery';
 
 const PinsOfTopic = lazy(() => import('../../components/PinsOfTopic'));
 
 function SelectedTopic() {
-  const { topicId } = useParams();
+  const { topicId } = useParams() as { topicId: string };
   const [searchParams, _] = useSearchParams();
-  const [topicDetail, setTopicDetail] = useState<TopicDetailProps | null>(null);
   const [selectedPinId, setSelectedPinId] = useState<number | null>(null);
   const [isOpen, setIsOpen] = useState(true);
   const [isEditPinDetail, setIsEditPinDetail] = useState<boolean>(false);
@@ -33,19 +32,13 @@ function SelectedTopic() {
   const { mapInstance } = useMapStore((state) => state);
   const { getDistanceOfPin } = useRealDistanceOfPin();
 
+  const { data: topicDetail, refetch: getTopicDetail } =
+    useTopicDetailQuery(topicId);
   const { tags, setTags, onClickInitTags, onClickCreateTopicWithTags } =
     useTags();
+
   useSetNavbarHighlight('none');
   useResizeMap();
-
-  const getAndSetDataFromServer = async () => {
-    const topicInArray = await getApi<TopicDetailProps[]>(
-      `/topics/ids?ids=${topicId}`,
-    );
-    const topic = topicInArray[0];
-
-    setTopicDetail(topic);
-  };
 
   const setClusteredCoordinates = async () => {
     if (!topicDetail || !mapInstance) return;
@@ -83,7 +76,6 @@ function SelectedTopic() {
   };
 
   useEffect(() => {
-    getAndSetDataFromServer();
     setTags([]);
   }, []);
 
@@ -156,7 +148,7 @@ function SelectedTopic() {
           topicDetail={topicDetail}
           setSelectedPinId={setSelectedPinId}
           setIsEditPinDetail={setIsEditPinDetail}
-          setTopicsFromServer={getAndSetDataFromServer}
+          setTopicsFromServer={getTopicDetail}
         />
       </Suspense>
 

--- a/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
+++ b/frontend/src/pages/SelectedTopic/SelectedTopic.page.tsx
@@ -2,22 +2,22 @@ import { lazy, Suspense, useContext, useEffect, useRef, useState } from 'react';
 import { useParams, useSearchParams } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { getApi } from '../apis/getApi';
-import Space from '../components/common/Space';
-import PullPin from '../components/PullPin';
-import PinsOfTopicSkeleton from '../components/Skeletons/PinsOfTopicSkeleton';
-import { LAYOUT_PADDING, PIN_SIZE, SIDEBAR } from '../constants';
-import { CoordinatesContext } from '../context/CoordinatesContext';
-import useRealDistanceOfPin from '../hooks/useRealDistanceOfPin';
-import useResizeMap from '../hooks/useResizeMap';
-import useSetLayoutWidth from '../hooks/useSetLayoutWidth';
-import useSetNavbarHighlight from '../hooks/useSetNavbarHighlight';
-import useTags from '../hooks/useTags';
-import useMapStore from '../store/mapInstance';
-import { TopicDetailProps } from '../types/Topic';
-import PinDetail from './PinDetail';
+import { getApi } from '../../apis/getApi';
+import Space from '../../components/common/Space';
+import PullPin from '../../components/PullPin';
+import PinsOfTopicSkeleton from '../../components/Skeletons/PinsOfTopicSkeleton';
+import { LAYOUT_PADDING, PIN_SIZE, SIDEBAR } from '../../constants';
+import { CoordinatesContext } from '../../context/CoordinatesContext';
+import useRealDistanceOfPin from '../../hooks/useRealDistanceOfPin';
+import useResizeMap from '../../hooks/useResizeMap';
+import useSetLayoutWidth from '../../hooks/useSetLayoutWidth';
+import useSetNavbarHighlight from '../../hooks/useSetNavbarHighlight';
+import useTags from '../../hooks/useTags';
+import useMapStore from '../../store/mapInstance';
+import { TopicDetailProps } from '../../types/Topic';
+import PinDetail from '../PinDetail';
 
-const PinsOfTopic = lazy(() => import('../components/PinsOfTopic'));
+const PinsOfTopic = lazy(() => import('../../components/PinsOfTopic'));
 
 function SelectedTopic() {
   const { Tmapv3 } = window;

--- a/frontend/src/pages/SelectedTopic/hooks/useClusterCoordinates.ts
+++ b/frontend/src/pages/SelectedTopic/hooks/useClusterCoordinates.ts
@@ -1,0 +1,48 @@
+import { useContext } from 'react';
+
+import { getClusteredCoordinates } from '../../../apis/new';
+import { CoordinatesContext } from '../../../context/CoordinatesContext';
+import useRealDistanceOfPin from '../../../hooks/useRealDistanceOfPin';
+import useMapStore from '../../../store/mapInstance';
+import { ClusteredCoordinates } from '../types';
+
+interface ClusteredCoordinatesWithTopicId extends ClusteredCoordinates {
+  topicId: string;
+  id: string;
+  pinName: string;
+}
+
+const useClusterCoordinates = (topicId: string) => {
+  const { mapInstance } = useMapStore((state) => state);
+  const { getDistanceOfPin } = useRealDistanceOfPin();
+  const { setCoordinates } = useContext(CoordinatesContext);
+
+  const setClusteredCoordinates = async () => {
+    if (!mapInstance) return;
+
+    const newCoordinates: ClusteredCoordinatesWithTopicId[] = [];
+    const diameterOfPinSize = getDistanceOfPin(mapInstance);
+
+    const responseData = await getClusteredCoordinates(
+      topicId,
+      diameterOfPinSize,
+    );
+
+    responseData.forEach((clusterOrPin: any, idx: number) => {
+      newCoordinates.push({
+        topicId,
+        id: clusterOrPin.pins[0].id || `cluster ${idx}`,
+        pinName: clusterOrPin.pins[0].name,
+        latitude: clusterOrPin.latitude,
+        longitude: clusterOrPin.longitude,
+        pins: clusterOrPin.pins,
+      });
+    });
+
+    setCoordinates(newCoordinates);
+  };
+
+  return setClusteredCoordinates;
+};
+
+export default useClusterCoordinates;

--- a/frontend/src/pages/SelectedTopic/hooks/useHandleMapInteraction.ts
+++ b/frontend/src/pages/SelectedTopic/hooks/useHandleMapInteraction.ts
@@ -1,0 +1,65 @@
+import { useContext, useEffect, useRef } from 'react';
+
+import { CoordinatesContext } from '../../../context/CoordinatesContext';
+import useMapStore from '../../../store/mapInstance';
+
+interface Props {
+  topicId: string;
+  onAfterInteraction: () => void;
+}
+
+const useHandleMapInteraction = ({ topicId, onAfterInteraction }: Props) => {
+  const { mapInstance } = useMapStore((state) => state);
+
+  const zoomTimerIdRef = useRef<NodeJS.Timeout | null>(null);
+  const dragTimerIdRef = useRef<NodeJS.Timeout | null>(null);
+  const { setCoordinates } = useContext(CoordinatesContext);
+
+  const setPrevCoordinates = () => {
+    setCoordinates((prev) => [...prev]);
+  };
+
+  const adjustMapDirection = () => {
+    if (!mapInstance) return;
+
+    mapInstance.setBearing(0);
+    mapInstance.setPitch(0);
+  };
+
+  useEffect(() => {
+    onAfterInteraction();
+
+    const onDragEnd = (evt: evt) => {
+      if (dragTimerIdRef.current) {
+        clearTimeout(dragTimerIdRef.current);
+      }
+
+      dragTimerIdRef.current = setTimeout(() => {
+        setPrevCoordinates();
+        adjustMapDirection();
+      }, 100);
+    };
+    const onZoomEnd = (evt: evt) => {
+      if (zoomTimerIdRef.current) {
+        clearTimeout(zoomTimerIdRef.current);
+      }
+
+      zoomTimerIdRef.current = setTimeout(() => {
+        onAfterInteraction();
+        adjustMapDirection();
+      }, 100);
+    };
+
+    if (!mapInstance) return;
+
+    mapInstance.on('DragEnd', onDragEnd);
+    mapInstance.on('ZoomEnd', onZoomEnd);
+
+    return () => {
+      mapInstance.off('DragEnd', onDragEnd);
+      mapInstance.off('ZoomEnd', onZoomEnd);
+    };
+  }, [topicId, mapInstance]);
+};
+
+export default useHandleMapInteraction;

--- a/frontend/src/pages/SelectedTopic/hooks/useSetSelectedPinId.ts
+++ b/frontend/src/pages/SelectedTopic/hooks/useSetSelectedPinId.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const useSetSelectedPinId = () => {
+  const [searchParams, _] = useSearchParams();
+  const [isDoubleSidebarOpen, setIsDoubleSidebarOpen] = useState(true);
+  const [selectedPinId, setSelectedPinId] = useState<number | null>(null);
+
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search);
+
+    if (queryParams.has('pinDetail')) {
+      setSelectedPinId(Number(queryParams.get('pinDetail')));
+      setIsDoubleSidebarOpen(true);
+      return;
+    }
+
+    setSelectedPinId(null);
+  }, [searchParams]);
+
+  return { isDoubleSidebarOpen, selectedPinId, setIsDoubleSidebarOpen, setSelectedPinId };
+};
+
+export default useSetSelectedPinId;

--- a/frontend/src/pages/SelectedTopic/hooks/useTopicDetailQuery.ts
+++ b/frontend/src/pages/SelectedTopic/hooks/useTopicDetailQuery.ts
@@ -1,0 +1,15 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getTopicDetail } from '../../../apis/new';
+
+const useTopicDetailQuery = (topicId: string) => {
+  const { data, refetch, ...rest } = useSuspenseQuery({
+    queryKey: ['topicDetail', topicId],
+    queryFn: () => getTopicDetail(topicId),
+    select: (response) => response[0],
+  });
+
+  return { data, refetch, ...rest };
+};
+
+export default useTopicDetailQuery;

--- a/frontend/src/pages/SelectedTopic/types/index.ts
+++ b/frontend/src/pages/SelectedTopic/types/index.ts
@@ -1,0 +1,11 @@
+export interface ClusteredCoordinates {
+  latitude: number;
+  longitude: number;
+  pins: ClusteredPin[];
+}
+
+interface ClusteredPin {
+  id: number;
+  name: string;
+  topicId: number;
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -8,7 +8,9 @@ import NotFound from './pages/NotFound';
 import RootPage from './pages/RootPage';
 import Search from './pages/Search';
 
-const SelectedTopic = lazy(() => import('./pages/SelectedTopic'));
+const SelectedTopic = lazy(
+  () => import('./pages/SelectedTopic/SelectedTopic.page'),
+);
 const NewPin = lazy(() => import('./pages/NewPin'));
 const NewTopic = lazy(() => import('./pages/NewTopic'));
 const SeeAllBestTopics = lazy(() => import('./pages/SeeAllBestTopics'));


### PR DESCRIPTION
<!-- 반드시 BE/FE 라벨과 리뷰어를 등록해주세요! -->

## 작업 대상
<!-- 작업한 대상을 자세히 설명해주세요. -->
* 단일 토픽 조회 (SelectedTopic) 페이지를 대상으로 합니다.

## 📄 작업 내용
<!-- 작업한 내용을 간단히 요약해주세요. -->
- [x] React Query 적용
  - [x] TopicDetail을 받아오는 부분을 React Query로 적용했습니다. 
- [x] 비즈니스 레이어 (custom hook, service) 적용으로 레이어 분리
  - [x] 서버로부터 클러스터링 정보를 받아오는 로직을 커스텀 훅으로 분리했습니다.
  - [x] 사용자가 지도를 드래그, 줌 할 때 발생하는 이벤트 처리 로직을 커스텀 훅으로 분리했습니다.
- [x] 그외 자잘한 오류 수정
  - [x] pin id 상태 세팅 및 쿼리 파라미터 조작 로직을 커스텀 훅으로 분리했습니다.
  - [x] setTags 커스텀 훅 내부로 tags를 초기화 하는 로직을 위치 시켰습니다.
 
## 🙋🏻 주의 사항
<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->
#### 1. 여전히 refetch 함수를 사용하고 있습니다.
refetch 함수 대신 queryClient.invalidateQueries를 통한 리페칭을 시도하고 싶었으나, 현재 구조상 다발적인 (여기 고치면, 저기 고치고, 또 저기 고치고..) 리팩토링이 예상되어 임시로 refetch 함수를 사용하였습니다.

#### 2. 과도한 추상화 및 커스텀 훅 분리 같다면 꼭 의견 부탁드립니다.
개인적으로 컴포넌트는 성공 케이스에 대한 UI 로직만 가져가면 좋겠다고 생각하여 보통 비즈니스 로직을 커스텀 훅으로 뺍니다. (재사용이 가능할 땐 더더욱 커스텀 훅으로 분리합니다.) 이 경우 과도한 추상화 및 커스텀 훅 분리가 이뤄질 수 있으며, 컴포넌트를 볼 때 해당 컴포넌트의 기능 (비즈니스 로직)이 훅으로 분리되어있기에 오히려 리팩토링 전보다 가독성이 떨어질 수도 있습니다.

아래 캡쳐본만 보고 해당 컴포넌트가 무슨 역할을 하는 것 같은지 대략적으로 예상이 가나요?
![image](https://github.com/woowacourse-teams/2023-map-befine/assets/89172499/2bc48fb7-0c7d-4a5c-94f9-1ed55452a0cf)

#### 3. 페이지 단위 코로케이션 디렉토리 구조를 가져가면 어떨지요.
이 부분은 사전에 공유드리지 않았는데, 페이지 단위로 사용하는 컴포넌트, 타입 파일, 훅 등을 위치시키는게 어떨까 제안 드립니다. 보통 페이지 컴포넌트를 폴더로 두고, 해당 페이지 내부에서 사용되는 컴포넌트, 훅 등을 위치시키게 됩니다. 저희가 리액트 쿼리를 도입하면서 페이지 별로 query 및 mutation 훅 로직이 많아질 예정인데 이 모든 훅이 글로벌 hooks 파일로 들어갈 경우, 꽤 복잡해질 것 같습니다.

#### 4. 페이지 컴포넌트 컨벤션으로 000.page.tsx 어떻습니까.
페이지 컴포넌트와 일반 컴포넌트가 구분이 모호하다고 생각합니다. 물론 pages, components 라는 폴더로 구분 짓고 있지만 작업물이 많아지면 생각보다 헷갈리더군요. 이 부분에서도 자유롭게 의견 부탁드립니다.

## 스크린샷
<!-- 필요한 경우 이해를 돕기위해 스크린샷을 올려주세요. -->

## 📎 관련 이슈
<!-- merge 시 close할 issue 번호를 입력해주세요. -->
close #655 
<!-- closed #번호 --> 

## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
